### PR TITLE
Close the WatchFace config activity only after the DataItem is written.

### DIFF
--- a/WatchFace/Wearable/src/main/java/com/example/android/wearable/watchface/config/DigitalWatchFaceConfigListenerService.java
+++ b/WatchFace/Wearable/src/main/java/com/example/android/wearable/watchface/config/DigitalWatchFaceConfigListenerService.java
@@ -73,7 +73,7 @@ public class DigitalWatchFaceConfigListenerService extends WearableListenerServi
             }
         }
 
-        DigitalWatchFaceUtil.overwriteKeysInConfigDataMap(mGoogleApiClient, configKeysToOverwrite);
+        DigitalWatchFaceUtil.overwriteKeysInConfigDataMap(mGoogleApiClient, configKeysToOverwrite, null);
     }
 
     @Override // GoogleApiClient.ConnectionCallbacks

--- a/WatchFace/Wearable/src/main/java/com/example/android/wearable/watchface/config/DigitalWatchFaceWearableConfigActivity.java
+++ b/WatchFace/Wearable/src/main/java/com/example/android/wearable/watchface/config/DigitalWatchFaceWearableConfigActivity.java
@@ -41,6 +41,7 @@ import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.api.GoogleApiClient;
 import com.google.android.gms.wearable.DataMap;
 import com.google.android.gms.wearable.Wearable;
+import java.util.concurrent.Callable;
 
 /**
  * The watch-side config activity for {@link DigitalWatchFaceService}, which allows for setting the
@@ -129,7 +130,6 @@ public class DigitalWatchFaceWearableConfigActivity extends Activity implements
     public void onClick(WearableListView.ViewHolder viewHolder) {
         ColorItemViewHolder colorItemViewHolder = (ColorItemViewHolder) viewHolder;
         updateConfigDataItem(colorItemViewHolder.mColorItem.getColor());
-        finish();
     }
 
     @Override // WearableListView.ClickListener
@@ -154,7 +154,14 @@ public class DigitalWatchFaceWearableConfigActivity extends Activity implements
         DataMap configKeysToOverwrite = new DataMap();
         configKeysToOverwrite.putInt(DigitalWatchFaceUtil.KEY_BACKGROUND_COLOR,
                 backgroundColor);
-        DigitalWatchFaceUtil.overwriteKeysInConfigDataMap(mGoogleApiClient, configKeysToOverwrite);
+        DigitalWatchFaceUtil.overwriteKeysInConfigDataMap(mGoogleApiClient, configKeysToOverwrite,
+            new Callable<Void>() {
+                @Override
+                public Void call() throws Exception {
+                    finish();
+                    return null;
+                }
+            });
     }
 
     private class ColorListAdapter extends WearableListView.Adapter {

--- a/WatchFace/Wearable/src/main/java/com/example/android/wearable/watchface/watchface/DigitalWatchFaceService.java
+++ b/WatchFace/Wearable/src/main/java/com/example/android/wearable/watchface/watchface/DigitalWatchFaceService.java
@@ -552,7 +552,7 @@ public class DigitalWatchFaceService extends CanvasWatchFaceService {
                             // If the DataItem hasn't been created yet or some keys are missing,
                             // use the default values.
                             setDefaultValuesForMissingConfigKeys(startupConfig);
-                            DigitalWatchFaceUtil.putConfigDataItem(mGoogleApiClient, startupConfig);
+                            DigitalWatchFaceUtil.putConfigDataItem(mGoogleApiClient, startupConfig, null);
 
                             updateUiForConfigDataMap(startupConfig);
                         }


### PR DESCRIPTION
Without this, there is a race between the time DataItem is being written and the fetch which happens right after the config activity closes.