### PR TITLE
Update to the Android Gradle plugin 4.0.0

### DIFF
--- a/AlwaysOn/README.md
+++ b/AlwaysOn/README.md
@@ -25,7 +25,7 @@ Pre-requisites
 --------------
 
 - Android SDK 28
-- Android Build Tools v28.0.3
+- Android Build Tools v29.0.2
 - Android Support Repository
 
 Screenshots

--- a/AlwaysOn/Wearable/build.gradle
+++ b/AlwaysOn/Wearable/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.2'
+        classpath 'com.android.tools.build:gradle:4.0.0'
     }
 }
 
@@ -45,8 +45,6 @@ List<String> dirs = [
 android {
 
     compileSdkVersion 28
-
-    buildToolsVersion "28.0.3"
 
     defaultConfig {
         versionCode 1

--- a/AlwaysOn/gradle/wrapper/gradle-wrapper.properties
+++ b/AlwaysOn/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip

--- a/DataLayer/Application/build.gradle
+++ b/DataLayer/Application/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.2'
+        classpath 'com.android.tools.build:gradle:4.0.0'
     }
 }
 

--- a/DataLayer/README.md
+++ b/DataLayer/README.md
@@ -28,7 +28,7 @@ Pre-requisites
 --------------
 
 - Android SDK 28
-- Android Build Tools v28.0.3
+- Android Build Tools v29.0.2
 - Android Support Repository
 
 Screenshots

--- a/DataLayer/Wearable/build.gradle
+++ b/DataLayer/Wearable/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.2'
+        classpath 'com.android.tools.build:gradle:4.0.0'
     }
 }
 
@@ -47,8 +47,6 @@ List<String> dirs = [
 android {
 
     compileSdkVersion 28
-
-    buildToolsVersion "28.0.3"
 
     defaultConfig {
         versionCode 1

--- a/DataLayer/gradle/wrapper/gradle-wrapper.properties
+++ b/DataLayer/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip

--- a/JumpingJack/README.md
+++ b/JumpingJack/README.md
@@ -45,7 +45,7 @@ Pre-requisites
 --------------
 
 - Android SDK 28
-- Android Build Tools v28.0.3
+- Android Build Tools v29.0.2
 - Android Support Repository
 
 Screenshots

--- a/JumpingJack/Wearable/build.gradle
+++ b/JumpingJack/Wearable/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.2'
+        classpath 'com.android.tools.build:gradle:4.0.0'
     }
 }
 
@@ -43,8 +43,6 @@ List<String> dirs = [
 android {
 
     compileSdkVersion 28
-
-    buildToolsVersion "28.0.3"
 
     defaultConfig {
         versionCode 1

--- a/JumpingJack/gradle/wrapper/gradle-wrapper.properties
+++ b/JumpingJack/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip

--- a/RuntimePermissionsWear/Application/build.gradle
+++ b/RuntimePermissionsWear/Application/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.2'
+        classpath 'com.android.tools.build:gradle:4.0.0'
     }
 }
 
@@ -38,8 +38,6 @@ List<String> dirs = [
 
 android {
     compileSdkVersion 28
-
-    buildToolsVersion "28.0.3"
 
     defaultConfig {
         minSdkVersion 18

--- a/RuntimePermissionsWear/README.md
+++ b/RuntimePermissionsWear/README.md
@@ -38,7 +38,7 @@ Pre-requisites
 --------------
 
 - Android SDK 28
-- Android Build Tools v28.0.3
+- Android Build Tools v29.0.2
 - Android Support Repository
 
 Screenshots

--- a/RuntimePermissionsWear/Shared/build.gradle
+++ b/RuntimePermissionsWear/Shared/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.2'
+        classpath 'com.android.tools.build:gradle:4.0.0'
     }
 }
 
@@ -29,8 +29,6 @@ List<String> dirs = [
 
 android {
     compileSdkVersion 28
-
-    buildToolsVersion "28.0.3"
 
     defaultConfig {
         minSdkVersion 18

--- a/RuntimePermissionsWear/Wearable/build.gradle
+++ b/RuntimePermissionsWear/Wearable/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.2'
+        classpath 'com.android.tools.build:gradle:4.0.0'
     }
 }
 
@@ -41,8 +41,6 @@ List<String> dirs = [
 android {
 
     compileSdkVersion 28
-
-    buildToolsVersion "28.0.3"
 
     defaultConfig {
         versionCode 1

--- a/RuntimePermissionsWear/gradle/wrapper/gradle-wrapper.properties
+++ b/RuntimePermissionsWear/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip

--- a/SpeedTracker/Application/build.gradle
+++ b/SpeedTracker/Application/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.2'
+        classpath 'com.android.tools.build:gradle:4.0.0'
     }
 }
 
@@ -39,8 +39,6 @@ List<String> dirs = [
 
 android {
     compileSdkVersion 28
-
-    buildToolsVersion "28.0.3"
 
     defaultConfig {
         minSdkVersion 18

--- a/SpeedTracker/README.md
+++ b/SpeedTracker/README.md
@@ -26,7 +26,7 @@ Pre-requisites
 --------------
 
 - Android SDK 28
-- Android Build Tools v28.0.3
+- Android Build Tools v29.0.2
 - Android Support Repository
 
 Screenshots

--- a/SpeedTracker/Shared/build.gradle
+++ b/SpeedTracker/Shared/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.2'
+        classpath 'com.android.tools.build:gradle:4.0.0'
     }
 }
 
@@ -29,8 +29,6 @@ List<String> dirs = [
 
 android {
     compileSdkVersion 28
-
-    buildToolsVersion "28.0.3"
 
     defaultConfig {
         minSdkVersion 18

--- a/SpeedTracker/Wearable/build.gradle
+++ b/SpeedTracker/Wearable/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.2'
+        classpath 'com.android.tools.build:gradle:4.0.0'
     }
 }
 
@@ -42,8 +42,6 @@ List<String> dirs = [
 android {
 
     compileSdkVersion 28
-
-    buildToolsVersion "28.0.3"
 
     defaultConfig {
         versionCode 1

--- a/SpeedTracker/gradle/wrapper/gradle-wrapper.properties
+++ b/SpeedTracker/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip

--- a/WatchFace/Application/build.gradle
+++ b/WatchFace/Application/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.2'
+        classpath 'com.android.tools.build:gradle:4.0.0'
     }
 }
 

--- a/WatchFace/README.md
+++ b/WatchFace/README.md
@@ -47,7 +47,7 @@ Pre-requisites
 --------------
 
 - Android SDK 28
-- Android Build Tools v28.0.3
+- Android Build Tools v29.0.2
 - Android Support Repository
 
 Screenshots

--- a/WatchFace/Wearable/build.gradle
+++ b/WatchFace/Wearable/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.2'
+        classpath 'com.android.tools.build:gradle:4.0.0'
     }
 }
 
@@ -44,8 +44,6 @@ List<String> dirs = [
 android {
 
     compileSdkVersion 28
-
-    buildToolsVersion "28.0.3"
 
     defaultConfig {
         versionCode 1

--- a/WatchFace/gradle/wrapper/gradle-wrapper.properties
+++ b/WatchFace/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip

--- a/WearAccessibilityApp/README.md
+++ b/WearAccessibilityApp/README.md
@@ -23,7 +23,7 @@ Pre-requisites
 --------------
 
 - Android SDK 28
-- Android Build Tools v28.0.3
+- Android Build Tools v29.0.2
 - Android Support Repository
 
 Screenshots

--- a/WearAccessibilityApp/Wearable/build.gradle
+++ b/WearAccessibilityApp/Wearable/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.2'
+        classpath 'com.android.tools.build:gradle:4.0.0'
     }
 }
 
@@ -48,8 +48,6 @@ List<String> dirs = [
 android {
 
     compileSdkVersion 28
-
-    buildToolsVersion "28.0.3"
 
     defaultConfig {
         versionCode 1

--- a/WearAccessibilityApp/gradle/wrapper/gradle-wrapper.properties
+++ b/WearAccessibilityApp/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip

--- a/WearComplicationProvidersTestSuite/README.md
+++ b/WearComplicationProvidersTestSuite/README.md
@@ -33,7 +33,7 @@ Pre-requisites
 --------------
 
 - Android SDK 28
-- Android Build Tools v28.0.3
+- Android Build Tools v29.0.2
 - Android Support Repository
 
 Screenshots

--- a/WearComplicationProvidersTestSuite/Wearable/build.gradle
+++ b/WearComplicationProvidersTestSuite/Wearable/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.2'
+        classpath 'com.android.tools.build:gradle:4.0.0'
     }
 }
 
@@ -45,8 +45,6 @@ List<String> dirs = [
 android {
 
     compileSdkVersion 28
-
-    buildToolsVersion "28.0.3"
 
     defaultConfig {
         versionCode 1

--- a/WearComplicationProvidersTestSuite/gradle/wrapper/gradle-wrapper.properties
+++ b/WearComplicationProvidersTestSuite/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip

--- a/WearDrawers/README.md
+++ b/WearDrawers/README.md
@@ -29,7 +29,7 @@ Pre-requisites
 --------------
 
 - Android SDK 28
-- Android Build Tools v28.0.3
+- Android Build Tools v29.0.2
 - Android Support Repository
 
 Screenshots

--- a/WearDrawers/Wearable/build.gradle
+++ b/WearDrawers/Wearable/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.2'
+        classpath 'com.android.tools.build:gradle:4.0.0'
     }
 }
 
@@ -40,8 +40,6 @@ List<String> dirs = [
 android {
 
     compileSdkVersion 28
-
-    buildToolsVersion "28.0.3"
 
     defaultConfig {
         versionCode 1

--- a/WearDrawers/gradle/wrapper/gradle-wrapper.properties
+++ b/WearDrawers/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip

--- a/WearHighBandwidthNetworking/README.md
+++ b/WearHighBandwidthNetworking/README.md
@@ -43,7 +43,7 @@ Pre-requisites
 --------------
 
 - Android SDK 28
-- Android Build Tools v28.0.3
+- Android Build Tools v29.0.2
 - Android Support Repository
 
 Screenshots

--- a/WearHighBandwidthNetworking/Wearable/build.gradle
+++ b/WearHighBandwidthNetworking/Wearable/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.2'
+        classpath 'com.android.tools.build:gradle:4.0.0'
     }
 }
 
@@ -45,8 +45,6 @@ List<String> dirs = [
 android {
 
     compileSdkVersion 28
-
-    buildToolsVersion "28.0.3"
 
     defaultConfig {
         versionCode 1

--- a/WearHighBandwidthNetworking/gradle/wrapper/gradle-wrapper.properties
+++ b/WearHighBandwidthNetworking/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip

--- a/WearOAuth/build.gradle
+++ b/WearOAuth/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.2'
+        classpath 'com.android.tools.build:gradle:4.0.0'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/WearOAuth/gradle/wrapper/gradle-wrapper.properties
+++ b/WearOAuth/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip

--- a/WearSpeakerSample/README.md
+++ b/WearSpeakerSample/README.md
@@ -12,7 +12,7 @@ Pre-requisites
 --------------
 
 - Android SDK v28
-- Android Build Tools v28.0.3
+- Android Build Tools v29.0.2
 - Android Support Repository
 
 Getting Started

--- a/WearSpeakerSample/build.gradle
+++ b/WearSpeakerSample/build.gradle
@@ -22,7 +22,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.2'
+        classpath 'com.android.tools.build:gradle:4.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/WearSpeakerSample/gradle/wrapper/gradle-wrapper.properties
+++ b/WearSpeakerSample/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip

--- a/WearStandaloneGoogleSignIn/build.gradle
+++ b/WearStandaloneGoogleSignIn/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.2'
+        classpath 'com.android.tools.build:gradle:4.0.0'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/WearStandaloneGoogleSignIn/gradle/wrapper/gradle-wrapper.properties
+++ b/WearStandaloneGoogleSignIn/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip

--- a/WearVerifyRemoteApp/Application/build.gradle
+++ b/WearVerifyRemoteApp/Application/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.2'
+        classpath 'com.android.tools.build:gradle:4.0.0'
     }
 }
 

--- a/WearVerifyRemoteApp/README.md
+++ b/WearVerifyRemoteApp/README.md
@@ -31,7 +31,7 @@ Pre-requisites
 --------------
 
 - Android SDK 28
-- Android Build Tools v28.0.3
+- Android Build Tools v29.0.2
 - Android Support Repository
 
 Screenshots

--- a/WearVerifyRemoteApp/Wearable/build.gradle
+++ b/WearVerifyRemoteApp/Wearable/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.2'
+        classpath 'com.android.tools.build:gradle:4.0.0'
     }
 }
 
@@ -45,8 +45,6 @@ List<String> dirs = [
 android {
 
     compileSdkVersion 28
-
-    buildToolsVersion "28.0.3"
 
     defaultConfig {
         versionCode 1

--- a/WearVerifyRemoteApp/gradle/wrapper/gradle-wrapper.properties
+++ b/WearVerifyRemoteApp/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip

--- a/XYZTouristAttractions/Application/build.gradle
+++ b/XYZTouristAttractions/Application/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.2'
+        classpath 'com.android.tools.build:gradle:4.0.0'
     }
 }
 
@@ -43,8 +43,6 @@ List<String> dirs = [
 
 android {
     compileSdkVersion 28
-
-    buildToolsVersion "28.0.3"
 
     defaultConfig {
         minSdkVersion 18

--- a/XYZTouristAttractions/README.md
+++ b/XYZTouristAttractions/README.md
@@ -100,7 +100,7 @@ Pre-requisites
 --------------
 
 - Android SDK 28
-- Android Build Tools v28.0.3
+- Android Build Tools v29.0.2
 - Android Support Repository
 
 Screenshots

--- a/XYZTouristAttractions/Shared/build.gradle
+++ b/XYZTouristAttractions/Shared/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.2'
+        classpath 'com.android.tools.build:gradle:4.0.0'
     }
 }
 
@@ -34,8 +34,6 @@ List<String> dirs = [
 
 android {
     compileSdkVersion 28
-
-    buildToolsVersion "28.0.3"
 
     defaultConfig {
         minSdkVersion 18

--- a/XYZTouristAttractions/Wearable/build.gradle
+++ b/XYZTouristAttractions/Wearable/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.2'
+        classpath 'com.android.tools.build:gradle:4.0.0'
     }
 }
 
@@ -42,8 +42,6 @@ List<String> dirs = [
 android {
 
     compileSdkVersion 28
-
-    buildToolsVersion "28.0.3"
 
     defaultConfig {
         versionCode 1

--- a/XYZTouristAttractions/gradle/wrapper/gradle-wrapper.properties
+++ b/XYZTouristAttractions/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip


### PR DESCRIPTION
buildToolsVersion is no longer required after version 3.1.0
Gradle plugin will automatically pick a minimum required
version (29.0.2 in this case).