### PR TITLE
[All] Remove pre-22 AndroidManifest flag

### DIFF
--- a/AlwaysOn/Wearable/src/main/AndroidManifest.xml
+++ b/AlwaysOn/Wearable/src/main/AndroidManifest.xml
@@ -30,9 +30,6 @@
             android:name="com.google.android.wearable.standalone"
             android:value="true" />
 
-        <!--If you want your app to run on pre-22, then set required to false -->
-        <uses-library android:name="com.google.android.wearable" android:required="false" />
-
         <!--
             To update the screen more than once per minute in ambient mode, developers should set
             the launch mode for the activity to single instance. Otherwise, the AlarmManager launch

--- a/RuntimePermissionsWear/Wearable/src/main/AndroidManifest.xml
+++ b/RuntimePermissionsWear/Wearable/src/main/AndroidManifest.xml
@@ -34,11 +34,6 @@
             android:name="com.google.android.gms.version"
             android:value="@integer/google_play_services_version" />
 
-        <!-- If you want your app to run on pre-22, then set required to false -->
-        <uses-library
-            android:name="com.google.android.wearable"
-            android:required="false" />
-
         <activity
             android:name=".MainWearActivity"
             android:label="@string/app_name"

--- a/WearDrawers/Wearable/src/main/AndroidManifest.xml
+++ b/WearDrawers/Wearable/src/main/AndroidManifest.xml
@@ -19,9 +19,6 @@
             android:name="com.google.android.wearable.standalone"
             android:value="true" />
 
-        <!--If you want your app to run on pre-22, then set required to false -->
-        <uses-library android:name="com.google.android.wearable" android:required="false" />
-
         <activity
             android:name=".MainActivity"
             android:label="@string/app_name">

--- a/WearSpeakerSample/wear/src/main/AndroidManifest.xml
+++ b/WearSpeakerSample/wear/src/main/AndroidManifest.xml
@@ -31,7 +31,6 @@
             android:name="com.google.android.wearable.standalone"
             android:value="true" />
 
-        <uses-library android:name="com.google.android.wearable" android:required="false" />
         <activity
             android:name=".MainActivity"
             android:label="@string/app_name" >

--- a/WearStandaloneGoogleSignIn/app/src/main/AndroidManifest.xml
+++ b/WearStandaloneGoogleSignIn/app/src/main/AndroidManifest.xml
@@ -30,10 +30,6 @@
             android:name="com.google.android.wearable.standalone"
             android:value="true" />
 
-        <uses-library
-            android:name="com.google.android.wearable"
-            android:required="false" />
-
         <activity
             android:name=".GoogleSignInActivity"
             android:label="@string/app_name">

--- a/WearVerifyRemoteApp/Wearable/src/main/AndroidManifest.xml
+++ b/WearVerifyRemoteApp/Wearable/src/main/AndroidManifest.xml
@@ -34,9 +34,6 @@
             android:name="com.google.android.wearable.standalone"
             android:value="true" />
 
-        <!--If you want your app to run on pre-22, then set required to false -->
-        <uses-library android:name="com.google.android.wearable" android:required="false" />
-
         <activity
             android:name=".MainWearActivity"
             android:label="@string/app_name"


### PR DESCRIPTION
Removes a no-longer relevant `AndroidManifest` entry from all samples that had it for supporting API levels before API 22.