### PR TITLE
 [AlwaysOn] Re-add uses-library tag

### DIFF
--- a/AlwaysOn/Wearable/src/main/AndroidManifest.xml
+++ b/AlwaysOn/Wearable/src/main/AndroidManifest.xml
@@ -31,6 +31,10 @@
             android:name="com.google.android.wearable.standalone"
             android:value="true" />
 
+        <uses-library
+            android:name="com.google.android.wearable"
+            android:required="false" />
+
         <!--
             To update the screen more than once per minute in ambient mode, developers should set
             the launch mode for the activity to single instance. Otherwise, the AlarmManager launch


### PR DESCRIPTION
A partial revert of #95. Without this tag, `AlwaysOn` will currently crash on startup with an `IllegalStateException`. The other samples where this tag was explicitly removed still have the tag included in their manifests via the dependency on `com.google.android.support:wearable:2.8.1` 