### PR TITLE
[AlwaysOn] Treat Kotlin warnings as errors

### DIFF
--- a/AlwaysOn/Wearable/build.gradle
+++ b/AlwaysOn/Wearable/build.gradle
@@ -36,6 +36,7 @@ android {
 
     kotlinOptions {
         jvmTarget = "1.8"
+        allWarningsAsErrors = true
     }
 
     buildFeatures {


### PR DESCRIPTION
Adds a flag to Kotlin compilation to fail upon any compile warnings. There are none right now, but this would require addressing things like deprecation warnings in order to successfully build.