### PR TITLE
[AlwaysOn] Update dependencies

### DIFF
--- a/AlwaysOnKotlin/Wearable/build.gradle
+++ b/AlwaysOnKotlin/Wearable/build.gradle
@@ -59,20 +59,20 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.0"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.1"
     implementation "androidx.activity:activity-ktx:1.2.3"
-    implementation "androidx.core:core-ktx:1.5.0"
-    implementation 'androidx.wear:wear:1.1.0'
+    implementation "androidx.core:core-ktx:1.6.0"
+    implementation 'androidx.wear:wear:1.2.0-alpha11'
 
-    androidTestImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.5.0"
-    androidTestImplementation "androidx.test:core:1.3.0"
-    androidTestImplementation "androidx.test:core-ktx:1.3.0"
-    androidTestImplementation "androidx.test.espresso:espresso-core:3.3.0"
-    androidTestImplementation "androidx.test.ext:junit:1.1.2"
-    androidTestImplementation "androidx.test.ext:junit-ktx:1.1.2"
-    androidTestImplementation "androidx.test.ext:truth:1.3.0"
-    androidTestImplementation "androidx.test:runner:1.3.0"
-    androidTestImplementation "androidx.test:rules:1.3.0"
+    androidTestImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.5.1"
+    androidTestImplementation "androidx.test:core:1.4.0"
+    androidTestImplementation "androidx.test:core-ktx:1.4.0"
+    androidTestImplementation "androidx.test.espresso:espresso-core:3.4.0"
+    androidTestImplementation "androidx.test.ext:junit:1.1.3"
+    androidTestImplementation "androidx.test.ext:junit-ktx:1.1.3"
+    androidTestImplementation "androidx.test.ext:truth:1.4.0"
+    androidTestImplementation "androidx.test:runner:1.4.0"
+    androidTestImplementation "androidx.test:rules:1.4.0"
     androidTestImplementation "androidx.test.uiautomator:uiautomator:2.2.0"
     androidTestImplementation "com.google.truth:truth:1.0"
 }

--- a/AlwaysOnKotlin/build.gradle
+++ b/AlwaysOnKotlin/build.gradle
@@ -15,14 +15,14 @@
  */
 
 buildscript {
-    ext.kotlin_version = "1.5.10"
+    ext.kotlin_version = "1.5.20"
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath "com.android.tools.build:gradle:4.2.1"
+        classpath "com.android.tools.build:gradle:4.2.2"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }


### PR DESCRIPTION
Bumps the `AlwaysOn` dependencies to latest, including to the latest alpha of the `androidx.wear` library.