### PR TITLE
Remove jcenter

### DIFF
--- a/DataLayer/Application/build.gradle
+++ b/DataLayer/Application/build.gradle
@@ -2,7 +2,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -14,7 +14,7 @@ apply plugin: 'com.android.application'
 
 repositories {
     google()
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/DataLayer/Wearable/build.gradle
+++ b/DataLayer/Wearable/build.gradle
@@ -2,7 +2,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -14,7 +14,7 @@ apply plugin: 'com.android.application'
 
 repositories {
     google()
-    jcenter()
+    mavenCentral()
 }
 
 

--- a/RuntimePermissionsWear/Application/build.gradle
+++ b/RuntimePermissionsWear/Application/build.gradle
@@ -2,7 +2,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -14,7 +14,7 @@ apply plugin: 'com.android.application'
 
 repositories {
     google()
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/RuntimePermissionsWear/Shared/build.gradle
+++ b/RuntimePermissionsWear/Shared/build.gradle
@@ -2,7 +2,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -14,7 +14,7 @@ apply plugin: 'com.android.library'
 
 repositories {
     google()
-    jcenter()
+    mavenCentral()
 }
 
 

--- a/RuntimePermissionsWear/Wearable/build.gradle
+++ b/RuntimePermissionsWear/Wearable/build.gradle
@@ -2,7 +2,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -14,7 +14,7 @@ apply plugin: 'com.android.application'
 
 repositories {
     google()
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/WatchFace/Application/build.gradle
+++ b/WatchFace/Application/build.gradle
@@ -2,7 +2,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -14,7 +14,7 @@ apply plugin: 'com.android.application'
 
 repositories {
     google()
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/WatchFace/Wearable/build.gradle
+++ b/WatchFace/Wearable/build.gradle
@@ -2,7 +2,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -14,7 +14,7 @@ apply plugin: 'com.android.application'
 
 repositories {
     google()
-    jcenter()
+    mavenCentral()
 }
 
 

--- a/WatchFaceAlphaKotlin/build.gradle
+++ b/WatchFaceAlphaKotlin/build.gradle
@@ -32,7 +32,7 @@ buildscript {
 
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -47,7 +47,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/WearAccessibilityApp/Wearable/build.gradle
+++ b/WearAccessibilityApp/Wearable/build.gradle
@@ -2,7 +2,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -14,7 +14,7 @@ apply plugin: 'com.android.application'
 
 repositories {
     google()
-    jcenter()
+    mavenCentral()
 }
 
 

--- a/WearDrawers/Wearable/build.gradle
+++ b/WearDrawers/Wearable/build.gradle
@@ -2,7 +2,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -14,7 +14,7 @@ apply plugin: 'com.android.application'
 
 repositories {
     google()
-    jcenter()
+    mavenCentral()
 }
 
 

--- a/WearStandaloneGoogleSignIn/build.gradle
+++ b/WearStandaloneGoogleSignIn/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.2'
@@ -15,7 +15,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/WearTilesKotlin/build.gradle
+++ b/WearTilesKotlin/build.gradle
@@ -18,7 +18,7 @@ buildscript {
     ext.kotlin_version = "1.5.20"
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.3'
@@ -33,7 +33,7 @@ plugins {
 subprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         maven { url 'https://jitpack.io' }
     }
 


### PR DESCRIPTION
Replaces jcenter with mavenCentral for all remaining places in this repo!

Verified via `./gradlew check` that each affected project still built with the repository update.