### PR TITLE
[AlwaysOn] Update to androidx.wear alpha12

### DIFF
--- a/AlwaysOnKotlin/Wearable/build.gradle
+++ b/AlwaysOnKotlin/Wearable/build.gradle
@@ -62,7 +62,7 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.1"
     implementation "androidx.activity:activity-ktx:1.2.3"
     implementation "androidx.core:core-ktx:1.6.0"
-    implementation 'androidx.wear:wear:1.2.0-alpha11'
+    implementation 'androidx.wear:wear:1.2.0-alpha12'
 
     androidTestImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.5.1"
     androidTestImplementation "androidx.test:core:1.4.0"

--- a/AlwaysOnKotlin/Wearable/src/main/AndroidManifest.xml
+++ b/AlwaysOnKotlin/Wearable/src/main/AndroidManifest.xml
@@ -32,10 +32,6 @@
             android:name="com.google.android.wearable.standalone"
             android:value="true" />
 
-        <uses-library
-            android:name="com.google.android.wearable"
-            android:required="false" />
-
         <!--
             To update the screen more than once per minute in ambient mode, developers should set
             the launch mode for the activity to single instance. Otherwise, the AlarmManager launch


### PR DESCRIPTION
Updates `AlwaysOn` to the latest version of `android.wear`, `alpha12`.

Due to https://android-review.googlesource.com/c/platform/frameworks/support/+/1749800/, this allows removing the tag from our `AndroidManifest.xml`.