### PR TITLE
Add spotless to updated samples

### DIFF
--- a/AlwaysOnKotlin/Wearable/build.gradle
+++ b/AlwaysOnKotlin/Wearable/build.gradle
@@ -60,7 +60,7 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.1"
-    implementation "androidx.activity:activity-ktx:1.2.3"
+    implementation "androidx.activity:activity-ktx:1.2.4"
     implementation "androidx.core:core-ktx:1.6.0"
     implementation 'androidx.wear:wear:1.2.0-alpha12'
 

--- a/AlwaysOnKotlin/Wearable/src/androidTest/java/com/example/android/wearable/wear/alwayson/MainActivityTests.kt
+++ b/AlwaysOnKotlin/Wearable/src/androidTest/java/com/example/android/wearable/wear/alwayson/MainActivityTests.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2021 The Android Open Source Project
+ * Copyright 2021 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -31,10 +31,6 @@ import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
-import java.time.Clock
-import java.time.Duration
-import java.time.Instant
-import java.time.ZoneId
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.TestCoroutineDispatcher
@@ -42,6 +38,10 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneId
 
 @RunWith(AndroidJUnit4::class)
 @OptIn(ExperimentalCoroutinesApi::class)

--- a/AlwaysOnKotlin/Wearable/src/main/java/com/example/android/wearable/wear/alwayson/MainActivity.kt
+++ b/AlwaysOnKotlin/Wearable/src/main/java/com/example/android/wearable/wear/alwayson/MainActivity.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2021 The Android Open Source Project
+ * Copyright 2021 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -30,6 +30,12 @@ import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.lifecycleScope
 import androidx.wear.ambient.AmbientModeSupport
 import com.example.android.wearable.wear.alwayson.databinding.ActivityMainBinding
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
@@ -37,12 +43,6 @@ import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 import java.util.Locale
 import kotlin.random.Random
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 /**
  * IMPORTANT NOTE: Most apps shouldn't use always on ambient mode, as it drains battery life. Unless

--- a/AlwaysOnKotlin/build.gradle
+++ b/AlwaysOnKotlin/build.gradle
@@ -27,9 +27,26 @@ buildscript {
     }
 }
 
+plugins {
+    id 'com.diffplug.spotless' version '5.14.2'
+}
+
 subprojects {
     repositories {
         google()
         mavenCentral()
+    }
+
+    apply plugin: "com.diffplug.spotless"
+
+    spotless {
+        kotlin {
+            target '**/*.kt'
+            targetExclude("$buildDir/**/*.kt")
+            targetExclude('bin/**/*.kt')
+
+            ktlint("0.41.0")
+            licenseHeaderFile rootProject.file('spotless/copyright.kt')
+        }
     }
 }

--- a/AlwaysOnKotlin/build.gradle
+++ b/AlwaysOnKotlin/build.gradle
@@ -15,7 +15,7 @@
  */
 
 buildscript {
-    ext.kotlin_version = "1.5.20"
+    ext.kotlin_version = "1.5.21"
     repositories {
         google()
         mavenCentral()

--- a/AlwaysOnKotlin/spotless/copyright.kt
+++ b/AlwaysOnKotlin/spotless/copyright.kt
@@ -1,0 +1,15 @@
+/*
+ * Copyright $YEAR The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/RuntimePermissionsWear/build.gradle
+++ b/RuntimePermissionsWear/build.gradle
@@ -27,9 +27,26 @@ buildscript {
     }
 }
 
+plugins {
+    id 'com.diffplug.spotless' version '5.14.2'
+}
+
 subprojects {
     repositories {
         google()
         mavenCentral()
+    }
+
+    apply plugin: "com.diffplug.spotless"
+
+    spotless {
+        kotlin {
+            target '**/*.kt'
+            targetExclude("$buildDir/**/*.kt")
+            targetExclude('bin/**/*.kt')
+
+            ktlint("0.41.0")
+            licenseHeaderFile rootProject.file('spotless/copyright.kt')
+        }
     }
 }

--- a/RuntimePermissionsWear/spotless/copyright.kt
+++ b/RuntimePermissionsWear/spotless/copyright.kt
@@ -1,0 +1,15 @@
+/*
+ * Copyright $YEAR The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/WearComplicationProvidersTestSuite/Wearable/build.gradle
+++ b/WearComplicationProvidersTestSuite/Wearable/build.gradle
@@ -59,6 +59,6 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.1"
     implementation "androidx.core:core-ktx:1.6.0"
-    implementation "androidx.datastore:datastore-preferences:1.0.0-rc01"
+    implementation "androidx.datastore:datastore-preferences:1.0.0-rc02"
     implementation "androidx.wear:wear-complications-provider:1.0.0-alpha17"
 }

--- a/WearComplicationProvidersTestSuite/Wearable/src/main/java/com/example/android/wearable/wear/wearcomplicationproviderstestsuite/ComplicationToggleArgs.kt
+++ b/WearComplicationProvidersTestSuite/Wearable/src/main/java/com/example/android/wearable/wear/wearcomplicationproviderstestsuite/ComplicationToggleArgs.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2021 The Android Open Source Project
+ * Copyright 2021 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/WearComplicationProvidersTestSuite/Wearable/src/main/java/com/example/android/wearable/wear/wearcomplicationproviderstestsuite/ComplicationToggleReceiver.kt
+++ b/WearComplicationProvidersTestSuite/Wearable/src/main/java/com/example/android/wearable/wear/wearcomplicationproviderstestsuite/ComplicationToggleReceiver.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2021 The Android Open Source Project
+ * Copyright 2021 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/WearComplicationProvidersTestSuite/Wearable/src/main/java/com/example/android/wearable/wear/wearcomplicationproviderstestsuite/DataStorage.kt
+++ b/WearComplicationProvidersTestSuite/Wearable/src/main/java/com/example/android/wearable/wear/wearcomplicationproviderstestsuite/DataStorage.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2021 The Android Open Source Project
+ * Copyright 2021 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/WearComplicationProvidersTestSuite/Wearable/src/main/java/com/example/android/wearable/wear/wearcomplicationproviderstestsuite/IconProviderService.kt
+++ b/WearComplicationProvidersTestSuite/Wearable/src/main/java/com/example/android/wearable/wear/wearcomplicationproviderstestsuite/IconProviderService.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2021 The Android Open Source Project
+ * Copyright 2021 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -22,7 +22,6 @@ import androidx.datastore.core.DataStore
 import androidx.wear.complications.ComplicationProviderService
 import androidx.wear.complications.ComplicationRequest
 import androidx.wear.complications.data.ComplicationData
-import androidx.wear.complications.data.ComplicationText
 import androidx.wear.complications.data.ComplicationType
 import androidx.wear.complications.data.MonochromaticImage
 import androidx.wear.complications.data.MonochromaticImageComplicationData

--- a/WearComplicationProvidersTestSuite/Wearable/src/main/java/com/example/android/wearable/wear/wearcomplicationproviderstestsuite/LargeImageProviderService.kt
+++ b/WearComplicationProvidersTestSuite/Wearable/src/main/java/com/example/android/wearable/wear/wearcomplicationproviderstestsuite/LargeImageProviderService.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2021 The Android Open Source Project
+ * Copyright 2021 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/WearComplicationProvidersTestSuite/Wearable/src/main/java/com/example/android/wearable/wear/wearcomplicationproviderstestsuite/LongTextProviderService.kt
+++ b/WearComplicationProvidersTestSuite/Wearable/src/main/java/com/example/android/wearable/wear/wearcomplicationproviderstestsuite/LongTextProviderService.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2021 The Android Open Source Project
+ * Copyright 2021 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/WearComplicationProvidersTestSuite/Wearable/src/main/java/com/example/android/wearable/wear/wearcomplicationproviderstestsuite/NoDataProviderService.kt
+++ b/WearComplicationProvidersTestSuite/Wearable/src/main/java/com/example/android/wearable/wear/wearcomplicationproviderstestsuite/NoDataProviderService.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2021 The Android Open Source Project
+ * Copyright 2021 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/WearComplicationProvidersTestSuite/Wearable/src/main/java/com/example/android/wearable/wear/wearcomplicationproviderstestsuite/RangedValueProviderService.kt
+++ b/WearComplicationProvidersTestSuite/Wearable/src/main/java/com/example/android/wearable/wear/wearcomplicationproviderstestsuite/RangedValueProviderService.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2021 The Android Open Source Project
+ * Copyright 2021 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/WearComplicationProvidersTestSuite/Wearable/src/main/java/com/example/android/wearable/wear/wearcomplicationproviderstestsuite/ShortTextProviderService.kt
+++ b/WearComplicationProvidersTestSuite/Wearable/src/main/java/com/example/android/wearable/wear/wearcomplicationproviderstestsuite/ShortTextProviderService.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2021 The Android Open Source Project
+ * Copyright 2021 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/WearComplicationProvidersTestSuite/Wearable/src/main/java/com/example/android/wearable/wear/wearcomplicationproviderstestsuite/SmallImageProviderService.kt
+++ b/WearComplicationProvidersTestSuite/Wearable/src/main/java/com/example/android/wearable/wear/wearcomplicationproviderstestsuite/SmallImageProviderService.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2021 The Android Open Source Project
+ * Copyright 2021 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/WearComplicationProvidersTestSuite/Wearable/src/main/java/com/example/android/wearable/wear/wearcomplicationproviderstestsuite/SuspendingComplicationProviderService.kt
+++ b/WearComplicationProvidersTestSuite/Wearable/src/main/java/com/example/android/wearable/wear/wearcomplicationproviderstestsuite/SuspendingComplicationProviderService.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2021 The Android Open Source Project
+ * Copyright 2021 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/WearComplicationProvidersTestSuite/build.gradle
+++ b/WearComplicationProvidersTestSuite/build.gradle
@@ -27,9 +27,26 @@ buildscript {
     }
 }
 
+plugins {
+    id 'com.diffplug.spotless' version '5.14.2'
+}
+
 subprojects {
     repositories {
         google()
         mavenCentral()
+    }
+
+    apply plugin: "com.diffplug.spotless"
+
+    spotless {
+        kotlin {
+            target '**/*.kt'
+            targetExclude("$buildDir/**/*.kt")
+            targetExclude('bin/**/*.kt')
+
+            ktlint("0.41.0")
+            licenseHeaderFile rootProject.file('spotless/copyright.kt')
+        }
     }
 }

--- a/WearComplicationProvidersTestSuite/build.gradle
+++ b/WearComplicationProvidersTestSuite/build.gradle
@@ -15,7 +15,7 @@
  */
 
 buildscript {
-    ext.kotlin_version = "1.5.20"
+    ext.kotlin_version = "1.5.21"
     repositories {
         google()
         mavenCentral()

--- a/WearComplicationProvidersTestSuite/spotless/copyright.kt
+++ b/WearComplicationProvidersTestSuite/spotless/copyright.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Android Open Source Project
+ * Copyright $YEAR The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,22 +13,3 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.example.android.wearable.wear.wearcomplicationproviderstestsuite
-
-/**
- * The enumerated list of all complications provided by this app.
- */
-enum class Complication(
-
-    /**
-     * A stable key that can be used to distinguish between this app's complications.
-     */
-    val key: String
-) {
-    ICON("Icon"),
-    LARGE_IMAGE("LargeImage"),
-    LONG_TEXT("LongText"),
-    RANGED_VALUE("RangedValue"),
-    SHORT_TEXT("ShortText"),
-    SMALL_IMAGE("SmallImage")
-}

--- a/WearSpeakerSample/build.gradle
+++ b/WearSpeakerSample/build.gradle
@@ -27,9 +27,26 @@ buildscript {
     }
 }
 
+plugins {
+    id 'com.diffplug.spotless' version '5.14.2'
+}
+
 subprojects {
     repositories {
         google()
         mavenCentral()
+    }
+
+    apply plugin: "com.diffplug.spotless"
+
+    spotless {
+        kotlin {
+            target '**/*.kt'
+            targetExclude("$buildDir/**/*.kt")
+            targetExclude('bin/**/*.kt')
+
+            ktlint("0.41.0")
+            licenseHeaderFile rootProject.file('spotless/copyright.kt')
+        }
     }
 }

--- a/WearSpeakerSample/build.gradle
+++ b/WearSpeakerSample/build.gradle
@@ -15,14 +15,14 @@
  */
 
 buildscript {
-    ext.kotlin_version = "1.5.10"
+    ext.kotlin_version = "1.5.21"
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath "com.android.tools.build:gradle:4.2.1"
+        classpath "com.android.tools.build:gradle:4.2.2"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/WearSpeakerSample/spotless/copyright.kt
+++ b/WearSpeakerSample/spotless/copyright.kt
@@ -1,0 +1,15 @@
+/*
+ * Copyright $YEAR The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/WearSpeakerSample/wear/build.gradle
+++ b/WearSpeakerSample/wear/build.gradle
@@ -45,14 +45,14 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.0"
-    implementation "androidx.activity:activity-ktx:1.2.3"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.1"
+    implementation "androidx.activity:activity-ktx:1.2.4"
     implementation "androidx.appcompat:appcompat:1.3.0"
     implementation "androidx.constraintlayout:constraintlayout:2.0.4"
-    implementation "androidx.core:core-ktx:1.5.0"
+    implementation "androidx.core:core-ktx:1.6.0"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.4.0-alpha02"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.4.0-alpha02"
-    implementation "androidx.media:media:1.3.1"
+    implementation "androidx.media:media:1.4.0"
     implementation "androidx.percentlayout:percentlayout:1.0.0"
     implementation "androidx.vectordrawable:vectordrawable-animated:1.1.0"
     implementation "androidx.wear:wear:1.1.0"

--- a/WearSpeakerSample/wear/src/main/java/com/example/android/wearable/speaker/MainActivity.kt
+++ b/WearSpeakerSample/wear/src/main/java/com/example/android/wearable/speaker/MainActivity.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2021 The Android Open Source Project
+ * Copyright 2021 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/WearSpeakerSample/wear/src/main/java/com/example/android/wearable/speaker/MainViewModel.kt
+++ b/WearSpeakerSample/wear/src/main/java/com/example/android/wearable/speaker/MainViewModel.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2021 The Android Open Source Project
+ * Copyright 2021 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/WearSpeakerSample/wear/src/main/java/com/example/android/wearable/speaker/MotionLayoutExt.kt
+++ b/WearSpeakerSample/wear/src/main/java/com/example/android/wearable/speaker/MotionLayoutExt.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2021 The Android Open Source Project
+ * Copyright 2021 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/WearSpeakerSample/wear/src/main/java/com/example/android/wearable/speaker/SoundRecorder.kt
+++ b/WearSpeakerSample/wear/src/main/java/com/example/android/wearable/speaker/SoundRecorder.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2021 The Android Open Source Project
+ * Copyright 2021 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/WearVerifyRemoteApp/build.gradle
+++ b/WearVerifyRemoteApp/build.gradle
@@ -27,9 +27,26 @@ buildscript {
     }
 }
 
+plugins {
+    id 'com.diffplug.spotless' version '5.14.2'
+}
+
 subprojects {
     repositories {
         google()
         mavenCentral()
+    }
+
+    apply plugin: "com.diffplug.spotless"
+
+    spotless {
+        kotlin {
+            target '**/*.kt'
+            targetExclude("$buildDir/**/*.kt")
+            targetExclude('bin/**/*.kt')
+
+            ktlint("0.41.0")
+            licenseHeaderFile rootProject.file('spotless/copyright.kt')
+        }
     }
 }

--- a/WearVerifyRemoteApp/spotless/copyright.kt
+++ b/WearVerifyRemoteApp/spotless/copyright.kt
@@ -1,0 +1,15 @@
+/*
+ * Copyright $YEAR The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */


### PR DESCRIPTION
Adds `spotless` to the recently updated samples, and also applies it to those that have been converted to Kotlin.

In particular, `AlwaysOn`, `Speaker`, and `Complications` all got spotless and had it applied, whereas `RuntimePermissions` and `VerifyRemote` just had it added.

I also updated a few dependencies so that `lint` was happy.