### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/AlwaysOnKotlin.yml
+++ b/.github/workflows/AlwaysOnKotlin.yml
@@ -55,6 +55,7 @@ jobs:
           path: ${{ env.SAMPLE_PATH }}/Wearable/build/reports
 
   android-test:
+    if: false # TODO: Try to enable and avoid flakiness
     needs: build
     runs-on: macOS-latest # enables hardware acceleration in the virtual machine
     timeout-minutes: 30

--- a/.github/workflows/AlwaysOnKotlin.yml
+++ b/.github/workflows/AlwaysOnKotlin.yml
@@ -1,0 +1,123 @@
+name: AlwaysOnKotlin
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'AlwaysOnKotlin/**'
+  pull_request:
+    paths:
+      - 'AlwaysOnKotlin/**'
+
+env:
+  SAMPLE_PATH: AlwaysOnKotlin
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Generate cache key
+        run: ./scripts/checksum.sh $SAMPLE_PATH checksum.txt
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches/modules-*
+            ~/.gradle/caches/jars-*
+            ~/.gradle/caches/build-cache-*
+          key: gradle-${{ hashFiles('checksum.txt') }}
+
+      - name: Build project
+        working-directory: ${{ env.SAMPLE_PATH }}
+        run: ./gradlew check --stacktrace
+
+      - name: Upload build outputs (APKs)
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-outputs
+          path: ${{ env.SAMPLE_PATH }}/Wearable/build/outputs
+
+      - name: Upload build reports
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-reports
+          path: ${{ env.SAMPLE_PATH }}/Wearable/build/reports
+
+  android-test:
+    needs: build
+    runs-on: macOS-latest # enables hardware acceleration in the virtual machine
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        profile: [ wear_round, wear_square ]
+        api-level: [ 26, 28, 30 ]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Generate cache key
+        run: ./scripts/checksum.sh $SAMPLE_PATH checksum.txt
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches/modules-*
+            ~/.gradle/caches/jars-*
+            ~/.gradle/caches/build-cache-*
+          key: gradle-${{ hashFiles('checksum.txt') }}
+
+      # android-emulator-runner currently doesn't support wear targets (https://github.com/ReactiveCircus/android-emulator-runner/issues/175)
+      # This is a bit if a weird workaround to still use the action, in a roundabout way.
+
+      # Setup the action with a fake emulator (downloads the cmdline-tools, etc.)
+      - name: Setup android-emulator-runner
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          target: google_apis
+          avd-name: fake
+          script: echo "Fake Android Emulator created"
+
+      # Manually download the Wear images that we need (--channel=1 is currently necessary for API 30 until it is released to the stable channel)
+      - name: Manually install Wear images
+        run: $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager --install 'system-images;android-${{ matrix.api-level }};android-wear;x86' --channel=1
+
+      # Manually create the Wear emulator, using the previously downloaded images
+      - name: Manually create Wear AVD
+        run: $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/avdmanager create avd --force -n "test" --abi 'android-wear/x86' --package 'system-images;android-${{ matrix.api-level }};android-wear;x86' -d ${{ matrix.profile }}
+
+      # Run the action again, but with force-avd-creation false. This skips some of the normal setup and validation, and uses the emulator we just created above.
+      - name: Run instrumentation tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          target: google_apis
+          force-avd-creation: false
+          avd-name: test
+          disable-animations: true
+          script: ./gradlew connectedCheck --stacktrace
+          working-directory: ${{ env.SAMPLE_PATH }}
+
+      - name: Upload test reports
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-reports
+          path: ${{ env.SAMPLE_PATH }}/Wearable/build/reports

--- a/.github/workflows/DataLayer.yml
+++ b/.github/workflows/DataLayer.yml
@@ -1,0 +1,59 @@
+name: DataLayer
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'DataLayer/**'
+  pull_request:
+    paths:
+      - 'DataLayer/**'
+
+env:
+  SAMPLE_PATH: DataLayer
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Generate cache key
+        run: ./scripts/checksum.sh $SAMPLE_PATH checksum.txt
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches/modules-*
+            ~/.gradle/caches/jars-*
+            ~/.gradle/caches/build-cache-*
+          key: gradle-${{ hashFiles('checksum.txt') }}
+
+      - name: Build project
+        working-directory: ${{ env.SAMPLE_PATH }}
+        run: ./gradlew check --stacktrace
+
+      - name: Upload build outputs (APKs)
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-outputs
+          path: |
+            ${{ env.SAMPLE_PATH }}/Wearable/build/outputs
+            ${{ env.SAMPLE_PATH }}/Application/build/outputs
+
+      - name: Upload build reports
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-reports
+          path: |
+            ${{ env.SAMPLE_PATH }}/Wearable/build/reports
+            ${{ env.SAMPLE_PATH }}/Application/build/reports

--- a/.github/workflows/RuntimePermissionsWear.yml
+++ b/.github/workflows/RuntimePermissionsWear.yml
@@ -1,0 +1,62 @@
+name: RuntimePermissionsWear
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'RuntimePermissionsWear/**'
+  pull_request:
+    paths:
+      - 'RuntimePermissionsWear/**'
+
+env:
+  SAMPLE_PATH: RuntimePermissionsWear
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Generate cache key
+        run: ./scripts/checksum.sh $SAMPLE_PATH checksum.txt
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches/modules-*
+            ~/.gradle/caches/jars-*
+            ~/.gradle/caches/build-cache-*
+          key: gradle-${{ hashFiles('checksum.txt') }}
+
+      - name: Build project
+        working-directory: ${{ env.SAMPLE_PATH }}
+        run: ./gradlew check --stacktrace
+
+      - name: Upload build outputs (APKs)
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-outputs
+          path: |
+            ${{ env.SAMPLE_PATH }}/Shared/build/outputs
+            ${{ env.SAMPLE_PATH }}/Wearable/build/outputs
+            ${{ env.SAMPLE_PATH }}/Application/build/outputs
+
+      - name: Upload build reports
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-reports
+          path: |
+            ${{ env.SAMPLE_PATH }}/Shared/build/reports
+            ${{ env.SAMPLE_PATH }}/Wearable/build/reports
+            ${{ env.SAMPLE_PATH }}/Application/build/reports

--- a/.github/workflows/WatchFaceAlphaKotlin.yml
+++ b/.github/workflows/WatchFaceAlphaKotlin.yml
@@ -1,0 +1,56 @@
+name: WatchFaceAlphaKotlin
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'WatchFaceAlphaKotlin/**'
+  pull_request:
+    paths:
+      - 'WatchFaceAlphaKotlin/**'
+
+env:
+  SAMPLE_PATH: WatchFaceAlphaKotlin
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Generate cache key
+        run: ./scripts/checksum.sh $SAMPLE_PATH checksum.txt
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches/modules-*
+            ~/.gradle/caches/jars-*
+            ~/.gradle/caches/build-cache-*
+          key: gradle-${{ hashFiles('checksum.txt') }}
+
+      - name: Build project
+        working-directory: ${{ env.SAMPLE_PATH }}
+        run: ./gradlew check --stacktrace
+
+      - name: Upload build outputs (APKs)
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-outputs
+          path: ${{ env.SAMPLE_PATH }}/app/build/outputs
+
+      - name: Upload build reports
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-reports
+          path: ${{ env.SAMPLE_PATH }}/app/build/reports

--- a/.github/workflows/WearComplicationDataSourcesTestSuite.yml
+++ b/.github/workflows/WearComplicationDataSourcesTestSuite.yml
@@ -1,0 +1,56 @@
+name: WearComplicationDataSourcesTestSuite
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'WearComplicationDataSourcesTestSuite/**'
+  pull_request:
+    paths:
+      - 'WearComplicationDataSourcesTestSuite/**'
+
+env:
+  SAMPLE_PATH: WearComplicationDataSourcesTestSuite
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Generate cache key
+        run: ./scripts/checksum.sh $SAMPLE_PATH checksum.txt
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches/modules-*
+            ~/.gradle/caches/jars-*
+            ~/.gradle/caches/build-cache-*
+          key: gradle-${{ hashFiles('checksum.txt') }}
+
+      - name: Build project
+        working-directory: ${{ env.SAMPLE_PATH }}
+        run: ./gradlew check --stacktrace
+
+      - name: Upload build outputs (APKs)
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-outputs
+          path: ${{ env.SAMPLE_PATH }}/Wearable/build/outputs
+
+      - name: Upload build reports
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-reports
+          path: ${{ env.SAMPLE_PATH }}/Wearable/build/reports

--- a/.github/workflows/WearOAuth.yml
+++ b/.github/workflows/WearOAuth.yml
@@ -1,0 +1,60 @@
+name: WearOAuth
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'WearOAuth/**'
+  pull_request:
+    paths:
+      - 'WearOAuth/**'
+
+env:
+  SAMPLE_PATH: WearOAuth
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Generate cache key
+        run: ./scripts/checksum.sh $SAMPLE_PATH checksum.txt
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches/modules-*
+            ~/.gradle/caches/jars-*
+            ~/.gradle/caches/build-cache-*
+          key: gradle-${{ hashFiles('checksum.txt') }}
+
+      - name: Build project
+        working-directory: ${{ env.SAMPLE_PATH }}
+        run: ./gradlew check --stacktrace
+
+      - name: Upload build outputs (APKs)
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-outputs
+          path: |
+            ${{ env.SAMPLE_PATH }}/oauth-pkce/build/outputs
+            ${{ env.SAMPLE_PATH }}/oauth-device-grant/build/outputs
+
+      - name: Upload build reports
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-reports
+          path: |
+            ${{ env.SAMPLE_PATH }}/oauth-pkce/build/reports
+            ${{ env.SAMPLE_PATH }}/oauth-device-grant/build/reports

--- a/.github/workflows/WearSpeakerSample.yml
+++ b/.github/workflows/WearSpeakerSample.yml
@@ -1,0 +1,56 @@
+name: WearSpeakerSample
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'WearSpeakerSample/**'
+  pull_request:
+    paths:
+      - 'WearSpeakerSample/**'
+
+env:
+  SAMPLE_PATH: WearSpeakerSample
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Generate cache key
+        run: ./scripts/checksum.sh $SAMPLE_PATH checksum.txt
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches/modules-*
+            ~/.gradle/caches/jars-*
+            ~/.gradle/caches/build-cache-*
+          key: gradle-${{ hashFiles('checksum.txt') }}
+
+      - name: Build project
+        working-directory: ${{ env.SAMPLE_PATH }}
+        run: ./gradlew check --stacktrace
+
+      - name: Upload build outputs (APKs)
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-outputs
+          path: ${{ env.SAMPLE_PATH }}/wear/build/outputs
+
+      - name: Upload build reports
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-reports
+          path: ${{ env.SAMPLE_PATH }}/wear/build/reports

--- a/.github/workflows/WearStandaloneGoogleSignIn.yml
+++ b/.github/workflows/WearStandaloneGoogleSignIn.yml
@@ -1,0 +1,56 @@
+name: WearStandaloneGoogleSignIn
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'WearStandaloneGoogleSignIn/**'
+  pull_request:
+    paths:
+      - 'WearStandaloneGoogleSignIn/**'
+
+env:
+  SAMPLE_PATH: WearStandaloneGoogleSignIn
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Generate cache key
+        run: ./scripts/checksum.sh $SAMPLE_PATH checksum.txt
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches/modules-*
+            ~/.gradle/caches/jars-*
+            ~/.gradle/caches/build-cache-*
+          key: gradle-${{ hashFiles('checksum.txt') }}
+
+      - name: Build project
+        working-directory: ${{ env.SAMPLE_PATH }}
+        run: ./gradlew check --stacktrace
+
+      - name: Upload build outputs (APKs)
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-outputs
+          path: ${{ env.SAMPLE_PATH }}/app/build/outputs
+
+      - name: Upload build reports
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-reports
+          path: ${{ env.SAMPLE_PATH }}/app/build/reports

--- a/.github/workflows/WearTilesKotlin.yml
+++ b/.github/workflows/WearTilesKotlin.yml
@@ -1,0 +1,56 @@
+name: WearTilesKotlin
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'WearTilesKotlin/**'
+  pull_request:
+    paths:
+      - 'WearTilesKotlin/**'
+
+env:
+  SAMPLE_PATH: WearTilesKotlin
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Generate cache key
+        run: ./scripts/checksum.sh $SAMPLE_PATH checksum.txt
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches/modules-*
+            ~/.gradle/caches/jars-*
+            ~/.gradle/caches/build-cache-*
+          key: gradle-${{ hashFiles('checksum.txt') }}
+
+      - name: Build project
+        working-directory: ${{ env.SAMPLE_PATH }}
+        run: ./gradlew check --stacktrace
+
+      - name: Upload build outputs (APKs)
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-outputs
+          path: ${{ env.SAMPLE_PATH }}/app/build/outputs
+
+      - name: Upload build reports
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-reports
+          path: ${{ env.SAMPLE_PATH }}/app/build/reports

--- a/.github/workflows/WearVerifyRemoteApp.yml
+++ b/.github/workflows/WearVerifyRemoteApp.yml
@@ -1,0 +1,60 @@
+name: WearVerifyRemoteApp
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'WearVerifyRemoteApp/**'
+  pull_request:
+    paths:
+      - 'WearVerifyRemoteApp/**'
+
+env:
+  SAMPLE_PATH: WearVerifyRemoteApp
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Generate cache key
+        run: ./scripts/checksum.sh $SAMPLE_PATH checksum.txt
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches/modules-*
+            ~/.gradle/caches/jars-*
+            ~/.gradle/caches/build-cache-*
+          key: gradle-${{ hashFiles('checksum.txt') }}
+
+      - name: Build project
+        working-directory: ${{ env.SAMPLE_PATH }}
+        run: ./gradlew check --stacktrace
+
+      - name: Upload build outputs (APKs)
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-outputs
+          path: |
+            ${{ env.SAMPLE_PATH }}/Application/build/outputs
+            ${{ env.SAMPLE_PATH }}/Wearable/build/outputs
+
+      - name: Upload build reports
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-reports
+          path: |
+            ${{ env.SAMPLE_PATH }}/Application/build/reports
+            ${{ env.SAMPLE_PATH }}/Wearable/build/reports

--- a/AlwaysOnKotlin/Wearable/build.gradle
+++ b/AlwaysOnKotlin/Wearable/build.gradle
@@ -33,6 +33,7 @@ android {
 
     lintOptions {
         warningsAsErrors true
+        ignore "OldTargetApi" // API >30 doesn't exist for Wear OS
     }
 
     compileOptions {
@@ -60,9 +61,9 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.1"
-    implementation "androidx.activity:activity-ktx:1.2.4"
+    implementation "androidx.activity:activity-ktx:1.3.1"
     implementation "androidx.core:core-ktx:1.6.0"
-    implementation 'androidx.wear:wear:1.2.0-alpha12'
+    implementation 'androidx.wear:wear:1.2.0-alpha13'
 
     androidTestImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.5.1"
     androidTestImplementation "androidx.test:core:1.4.0"
@@ -74,5 +75,5 @@ dependencies {
     androidTestImplementation "androidx.test:runner:1.4.0"
     androidTestImplementation "androidx.test:rules:1.4.0"
     androidTestImplementation "androidx.test.uiautomator:uiautomator:2.2.0"
-    androidTestImplementation "com.google.truth:truth:1.0"
+    androidTestImplementation "com.google.truth:truth:1.1.2"
 }

--- a/AlwaysOnKotlin/Wearable/src/main/AndroidManifest.xml
+++ b/AlwaysOnKotlin/Wearable/src/main/AndroidManifest.xml
@@ -18,7 +18,8 @@
           package="com.example.android.wearable.wear.alwayson">
 
     <uses-permission android:name="android.permission.WAKE_LOCK" />
-    <uses-permission android:name="com.android.alarm.permission.SET_ALARM"/>
+    <uses-permission android:name="com.android.alarm.permission.SET_ALARM" />
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
 
     <uses-feature android:name="android.hardware.type.watch" />
 

--- a/AlwaysOnKotlin/Wearable/src/main/java/com/example/android/wearable/wear/alwayson/MainActivity.kt
+++ b/AlwaysOnKotlin/Wearable/src/main/java/com/example/android/wearable/wear/alwayson/MainActivity.kt
@@ -143,7 +143,10 @@ class MainActivity : FragmentActivity(), AmbientModeSupport.AmbientCallbackProvi
          * every time the Alarm is triggered rather than reusing this Activity.
          */
         ambientUpdatePendingIntent = PendingIntent.getBroadcast(
-            this, 0, ambientUpdateIntent, PendingIntent.FLAG_UPDATE_CURRENT
+            this,
+            0,
+            ambientUpdateIntent,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
         )
 
         /*

--- a/AlwaysOnKotlin/build.gradle
+++ b/AlwaysOnKotlin/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "com.android.tools.build:gradle:4.2.2"
+        classpath "com.android.tools.build:gradle:7.0.0"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/RuntimePermissionsWear/Wearable/build.gradle
+++ b/RuntimePermissionsWear/Wearable/build.gradle
@@ -31,6 +31,10 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
+    lintOptions {
+        ignore "OldTargetApi" // API >30 doesn't exist for Wear OS
+    }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
@@ -49,10 +53,10 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.1"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.5.1"
     implementation "androidx.appcompat:appcompat:1.3.1"
-    implementation "androidx.activity:activity-ktx:1.3.0"
-    implementation "androidx.constraintlayout:constraintlayout:2.0.4"
+    implementation "androidx.activity:activity-ktx:1.3.1"
+    implementation "androidx.constraintlayout:constraintlayout:2.1.0"
     implementation "androidx.core:core-ktx:1.6.0"
-    implementation "androidx.wear:wear:1.2.0-alpha12"
+    implementation "androidx.wear:wear:1.2.0-alpha13"
     implementation "com.google.android.gms:play-services-wearable:17.1.0"
 
     implementation project(':Shared')

--- a/WearComplicationDataSourcesTestSuite/Wearable/build.gradle
+++ b/WearComplicationDataSourcesTestSuite/Wearable/build.gradle
@@ -32,6 +32,7 @@ android {
 
     lintOptions {
         warningsAsErrors true
+        ignore "OldTargetApi" // API >30 doesn't exist for Wear OS
     }
 
     buildTypes {
@@ -59,6 +60,6 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.1"
     implementation "androidx.core:core-ktx:1.6.0"
-    implementation "androidx.datastore:datastore-preferences:1.0.0-rc02"
-    implementation "androidx.wear:wear-complications-data-source:1.0.0-alpha18"
+    implementation "androidx.datastore:datastore-preferences:1.0.0"
+    implementation "androidx.wear:wear-complications-data-source:1.0.0-alpha19"
 }

--- a/WearComplicationDataSourcesTestSuite/Wearable/src/main/AndroidManifest.xml
+++ b/WearComplicationDataSourcesTestSuite/Wearable/src/main/AndroidManifest.xml
@@ -20,12 +20,13 @@
     android:versionCode="1"
     android:versionName="1.0">
 
-    <uses-feature android:name="android.hardware.type.watch"/>
+    <uses-feature android:name="android.hardware.type.watch" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
 
-    <application android:allowBackup="true"
-        android:label="@string/app_name"
+    <application
+        android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
+        android:label="@string/app_name"
         android:theme="@style/AppTheme"
         tools:ignore="AllowBackup">
 
@@ -34,128 +35,135 @@
             android:value="true" />
         <uses-library
             android:name="com.google.android.wearable"
-            android:required="false"/>
+            android:required="false" />
 
 
         <service
+            android:name=".NoDataDataSourceService"
+            android:exported="true"
             android:icon="@drawable/ic_not_interested_vd_theme_24"
             android:label="@string/no_data_label"
-            android:name=".NoDataDataSourceService"
             android:permission="com.google.android.wearable.permission.BIND_COMPLICATION_PROVIDER">
             <intent-filter>
-                <action android:name="android.support.wearable.complications.ACTION_COMPLICATION_UPDATE_REQUEST"/>
+                <action android:name="android.support.wearable.complications.ACTION_COMPLICATION_UPDATE_REQUEST" />
             </intent-filter>
 
             <meta-data
                 android:name="android.support.wearable.complications.SUPPORTED_TYPES"
-                android:value="SHORT_TEXT,LONG_TEXT,SMALL_IMAGE,ICON,RANGED_VALUE,LARGE_IMAGE"/>
+                android:value="SHORT_TEXT,LONG_TEXT,SMALL_IMAGE,ICON,RANGED_VALUE,LARGE_IMAGE" />
             <meta-data
                 android:name="android.support.wearable.complications.UPDATE_PERIOD_SECONDS"
-                android:value="0"/>
+                android:value="0" />
         </service>
 
         <service
+            android:name=".ShortTextDataSourceService"
+            android:exported="true"
             android:icon="@drawable/ic_title_vd_theme_24"
             android:label="@string/short_text_label"
-            android:name=".ShortTextDataSourceService"
             android:permission="com.google.android.wearable.permission.BIND_COMPLICATION_PROVIDER">
             <intent-filter>
-                <action android:name="android.support.wearable.complications.ACTION_COMPLICATION_UPDATE_REQUEST"/>
+                <action android:name="android.support.wearable.complications.ACTION_COMPLICATION_UPDATE_REQUEST" />
             </intent-filter>
 
             <meta-data
                 android:name="android.support.wearable.complications.SUPPORTED_TYPES"
-                android:value="SHORT_TEXT"/>
+                android:value="SHORT_TEXT" />
             <meta-data
                 android:name="android.support.wearable.complications.UPDATE_PERIOD_SECONDS"
-                android:value="0"/>
+                android:value="0" />
         </service>
 
         <service
+            android:name=".SmallImageDataSourceService"
+            android:exported="true"
             android:icon="@drawable/ic_image_vd_theme_24"
             android:label="@string/small_image_label"
-            android:name=".SmallImageDataSourceService"
             android:permission="com.google.android.wearable.permission.BIND_COMPLICATION_PROVIDER">
             <intent-filter>
-                <action android:name="android.support.wearable.complications.ACTION_COMPLICATION_UPDATE_REQUEST"/>
+                <action android:name="android.support.wearable.complications.ACTION_COMPLICATION_UPDATE_REQUEST" />
             </intent-filter>
 
             <meta-data
                 android:name="android.support.wearable.complications.SUPPORTED_TYPES"
-                android:value="SMALL_IMAGE"/>
+                android:value="SMALL_IMAGE" />
             <meta-data
                 android:name="android.support.wearable.complications.UPDATE_PERIOD_SECONDS"
-                android:value="0"/>
+                android:value="0" />
         </service>
 
         <service
+            android:name=".LargeImageDataSourceService"
+            android:exported="true"
             android:icon="@drawable/ic_landscape_vd_theme_24"
             android:label="@string/large_image_label"
-            android:name=".LargeImageDataSourceService"
             android:permission="com.google.android.wearable.permission.BIND_COMPLICATION_PROVIDER">
             <intent-filter>
-                <action android:name="android.support.wearable.complications.ACTION_COMPLICATION_UPDATE_REQUEST"/>
+                <action android:name="android.support.wearable.complications.ACTION_COMPLICATION_UPDATE_REQUEST" />
             </intent-filter>
 
             <meta-data
                 android:name="android.support.wearable.complications.SUPPORTED_TYPES"
-                android:value="LARGE_IMAGE"/>
+                android:value="LARGE_IMAGE" />
             <meta-data
                 android:name="android.support.wearable.complications.UPDATE_PERIOD_SECONDS"
-                android:value="0"/>
+                android:value="0" />
         </service>
 
         <service
+            android:name=".IconDataSourceService"
+            android:exported="true"
             android:icon="@drawable/ic_face_vd_theme_24"
             android:label="@string/icon_label"
-            android:name=".IconDataSourceService"
             android:permission="com.google.android.wearable.permission.BIND_COMPLICATION_PROVIDER">
             <intent-filter>
-                <action android:name="android.support.wearable.complications.ACTION_COMPLICATION_UPDATE_REQUEST"/>
+                <action android:name="android.support.wearable.complications.ACTION_COMPLICATION_UPDATE_REQUEST" />
             </intent-filter>
 
             <meta-data
                 android:name="android.support.wearable.complications.SUPPORTED_TYPES"
-                android:value="ICON"/>
+                android:value="ICON" />
             <meta-data
                 android:name="android.support.wearable.complications.UPDATE_PERIOD_SECONDS"
-                android:value="0"/>
+                android:value="0" />
         </service>
 
         <service
+            android:name=".LongTextDataSourceService"
+            android:exported="true"
             android:icon="@drawable/ic_short_text_vd_theme_24"
             android:label="@string/long_text_label"
-            android:name=".LongTextDataSourceService"
             android:permission="com.google.android.wearable.permission.BIND_COMPLICATION_PROVIDER">
             <intent-filter>
-                <action android:name="android.support.wearable.complications.ACTION_COMPLICATION_UPDATE_REQUEST"/>
+                <action android:name="android.support.wearable.complications.ACTION_COMPLICATION_UPDATE_REQUEST" />
             </intent-filter>
 
             <meta-data
                 android:name="android.support.wearable.complications.SUPPORTED_TYPES"
-                android:value="LONG_TEXT"/>
+                android:value="LONG_TEXT" />
             <meta-data
                 android:name="android.support.wearable.complications.UPDATE_PERIOD_SECONDS"
-                android:value="0"/>
+                android:value="0" />
         </service>
 
         <service
+            android:name=".RangedValueDataSourceService"
+            android:exported="true"
             android:icon="@drawable/ic_data_usage_vd_theme_24"
             android:label="@string/ranged_value_label"
-            android:name=".RangedValueDataSourceService"
             android:permission="com.google.android.wearable.permission.BIND_COMPLICATION_PROVIDER">
             <intent-filter>
-                <action android:name="android.support.wearable.complications.ACTION_COMPLICATION_UPDATE_REQUEST"/>
+                <action android:name="android.support.wearable.complications.ACTION_COMPLICATION_UPDATE_REQUEST" />
             </intent-filter>
 
             <meta-data
                 android:name="android.support.wearable.complications.SUPPORTED_TYPES"
-                android:value="RANGED_VALUE"/>
+                android:value="RANGED_VALUE" />
             <meta-data
                 android:name="android.support.wearable.complications.UPDATE_PERIOD_SECONDS"
-                android:value="0"/>
+                android:value="0" />
         </service>
 
-        <receiver android:name=".ComplicationToggleReceiver"/>
+        <receiver android:name=".ComplicationToggleReceiver" />
     </application>
 </manifest>

--- a/WearOAuth/oauth-device-grant/build.gradle
+++ b/WearOAuth/oauth-device-grant/build.gradle
@@ -26,6 +26,10 @@ android {
         versionName "1.0"
     }
 
+    lintOptions {
+        ignore "OldTargetApi" // API >30 doesn't exist for Wear OS
+    }
+
     // Used to make the direct HTTP call for the token exchange. This will eventually be removed
     // when the sample is updated to use server-side redirects.
     useLibrary 'org.apache.http.legacy'
@@ -48,10 +52,10 @@ dependencies {
     implementation project(':util')
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'androidx.core:core-ktx:1.6.0'
-    implementation 'androidx.appcompat:appcompat:1.3.0'
+    implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.3.1")
     implementation("androidx.fragment:fragment-ktx:1.3.6")
     implementation("androidx.wear:wear:1.1.0")
-    implementation("androidx.wear:wear-remote-interactions:1.0.0-alpha05")
+    implementation("androidx.wear:wear-remote-interactions:1.0.0-alpha06")
     implementation 'com.google.android.gms:play-services-wearable:17.1.0'
 }

--- a/WearOAuth/oauth-pkce/build.gradle
+++ b/WearOAuth/oauth-pkce/build.gradle
@@ -20,7 +20,6 @@ plugins {
 
 android {
     compileSdkVersion 30
-    buildToolsVersion "30.0.3"
 
     defaultConfig {
         applicationId "com.example.android.wearable.oauth.pkce"
@@ -29,6 +28,10 @@ android {
         versionCode 1
         versionName "1.0"
 
+    }
+
+    lintOptions {
+        ignore "OldTargetApi" // API >30 doesn't exist for Wear OS
     }
 
     buildTypes {
@@ -50,6 +53,6 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.3.1")
     implementation("androidx.fragment:fragment-ktx:1.3.6")
     implementation("androidx.wear:wear:1.1.0")
-    implementation("androidx.wear:wear-phone-interactions:1.0.0-alpha06")
+    implementation("androidx.wear:wear-phone-interactions:1.0.0-alpha07")
     implementation 'com.google.android.gms:play-services-wearable:17.1.0'
 }

--- a/WearOAuth/oauth-pkce/src/main/java/com/example/android/wearable/oauth/pkce/AuthPKCEActivity.kt
+++ b/WearOAuth/oauth-pkce/src/main/java/com/example/android/wearable/oauth/pkce/AuthPKCEActivity.kt
@@ -41,7 +41,7 @@ class AuthPKCEActivity : ComponentActivity() {
 
         // Start the OAuth flow when the user presses the button
         findViewById<View>(R.id.authenticateButton).setOnClickListener {
-            viewModel.startAuthFlow(applicationContext.packageName)
+            viewModel.startAuthFlow()
         }
 
         // Show current status on the screen

--- a/WearSpeakerSample/build.gradle
+++ b/WearSpeakerSample/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "com.android.tools.build:gradle:4.2.2"
+        classpath "com.android.tools.build:gradle:7.0.0"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/WearSpeakerSample/wear/build.gradle
+++ b/WearSpeakerSample/wear/build.gradle
@@ -30,6 +30,10 @@ android {
         targetSdkVersion 30
     }
 
+    lintOptions {
+        ignore "OldTargetApi" // API >30 doesn't exist for Wear OS
+    }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
@@ -46,13 +50,13 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.1"
-    implementation "androidx.activity:activity-ktx:1.2.4"
-    implementation "androidx.appcompat:appcompat:1.3.0"
-    implementation "androidx.constraintlayout:constraintlayout:2.0.4"
+    implementation "androidx.activity:activity-ktx:1.3.1"
+    implementation "androidx.appcompat:appcompat:1.3.1"
+    implementation "androidx.constraintlayout:constraintlayout:2.1.0"
     implementation "androidx.core:core-ktx:1.6.0"
-    implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.4.0-alpha02"
-    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.4.0-alpha02"
-    implementation "androidx.media:media:1.4.0"
+    implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.4.0-alpha03"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.4.0-alpha03"
+    implementation "androidx.media:media:1.4.1"
     implementation "androidx.percentlayout:percentlayout:1.0.0"
     implementation "androidx.vectordrawable:vectordrawable-animated:1.1.0"
     implementation "androidx.wear:wear:1.1.0"

--- a/WearSpeakerSample/wear/src/main/AndroidManifest.xml
+++ b/WearSpeakerSample/wear/src/main/AndroidManifest.xml
@@ -36,7 +36,8 @@
 
         <activity
             android:name=".MainActivity"
-            android:label="@string/app_name">
+            android:label="@string/app_name"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/WearTilesKotlin/app/build.gradle
+++ b/WearTilesKotlin/app/build.gradle
@@ -28,6 +28,10 @@ android {
         versionName "1.0"
     }
 
+    lintOptions {
+        ignore "OldTargetApi" // API >30 doesn't exist for Wear OS
+    }
+
     buildTypes {
         release {
             minifyEnabled false
@@ -46,13 +50,13 @@ android {
 }
 
 dependencies {
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.0'
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-guava:1.5.0'
-    implementation 'androidx.core:core-ktx:1.3.2'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.1'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-guava:1.5.1'
+    implementation 'androidx.core:core-ktx:1.6.0'
     implementation 'androidx.wear:wear:1.1.0'
     // Use to implement support for wear tiles
-    implementation "androidx.wear.tiles:tiles:1.0.0-alpha08"
+    implementation "androidx.wear.tiles:tiles:1.0.0-alpha09"
 
     // Use to preview wear tiles in your own app
-    debugImplementation "androidx.wear.tiles:tiles-renderer:1.0.0-alpha08"
+    debugImplementation "androidx.wear.tiles:tiles-renderer:1.0.0-alpha09"
 }

--- a/WearTilesKotlin/app/src/main/AndroidManifest.xml
+++ b/WearTilesKotlin/app/src/main/AndroidManifest.xml
@@ -29,6 +29,7 @@
 
         <service
             android:name="com.example.wear.tiles.fitness.FitnessTileService"
+            android:exported="true"
             android:label="@string/tile_fitness_label"
             android:description="@string/tile_description"
             android:icon="@drawable/ic_run"
@@ -44,6 +45,7 @@
         </service>
         <service
             android:name="com.example.wear.tiles.media.PlayNextSongTileService"
+            android:exported="true"
             android:label="@string/tile_media_label"
             android:description="@string/tile_description"
             android:icon="@drawable/ic_play"
@@ -58,6 +60,7 @@
         </service>
         <service
             android:name="com.example.wear.tiles.messaging.MessagingTileService"
+            android:exported="true"
             android:label="@string/tile_messaging_label"
             android:description="@string/tile_description"
             android:icon="@drawable/ic_person"

--- a/WearTilesKotlin/app/src/main/java/com/example/wear/tiles/fitness/FitnessTileService.kt
+++ b/WearTilesKotlin/app/src/main/java/com/example/wear/tiles/fitness/FitnessTileService.kt
@@ -16,7 +16,6 @@
 package com.example.wear.tiles.fitness
 
 import androidx.core.content.ContextCompat
-import androidx.wear.tiles.TileProviderService
 import androidx.wear.tiles.ColorBuilders.argb
 import androidx.wear.tiles.DeviceParametersBuilders.DeviceParameters
 import androidx.wear.tiles.DimensionBuilders.degrees
@@ -31,12 +30,13 @@ import androidx.wear.tiles.LayoutElementBuilders.Layout
 import androidx.wear.tiles.LayoutElementBuilders.Text
 import androidx.wear.tiles.ModifiersBuilders.Modifiers
 import androidx.wear.tiles.ModifiersBuilders.Semantics
-import androidx.wear.tiles.ResourceBuilders.Resources
-import androidx.wear.tiles.TileBuilders.Tile
-import androidx.wear.tiles.TimelineBuilders.Timeline
-import androidx.wear.tiles.TimelineBuilders.TimelineEntry
 import androidx.wear.tiles.RequestBuilders.ResourcesRequest
 import androidx.wear.tiles.RequestBuilders.TileRequest
+import androidx.wear.tiles.ResourceBuilders.Resources
+import androidx.wear.tiles.TileBuilders.Tile
+import androidx.wear.tiles.TileProviderService
+import androidx.wear.tiles.TimelineBuilders.Timeline
+import androidx.wear.tiles.TimelineBuilders.TimelineEntry
 import com.example.wear.tiles.R
 import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture

--- a/WearTilesKotlin/app/src/main/java/com/example/wear/tiles/media/PlayNextSongTileService.kt
+++ b/WearTilesKotlin/app/src/main/java/com/example/wear/tiles/media/PlayNextSongTileService.kt
@@ -17,7 +17,6 @@ package com.example.wear.tiles.media
 
 import androidx.core.content.ContextCompat
 import androidx.wear.tiles.ActionBuilders
-import androidx.wear.tiles.TileProviderService
 import androidx.wear.tiles.ColorBuilders.argb
 import androidx.wear.tiles.DeviceParametersBuilders.DeviceParameters
 import androidx.wear.tiles.DimensionBuilders.dp
@@ -31,14 +30,15 @@ import androidx.wear.tiles.LayoutElementBuilders.Text
 import androidx.wear.tiles.ModifiersBuilders.Clickable
 import androidx.wear.tiles.ModifiersBuilders.Modifiers
 import androidx.wear.tiles.ModifiersBuilders.Semantics
+import androidx.wear.tiles.RequestBuilders.ResourcesRequest
+import androidx.wear.tiles.RequestBuilders.TileRequest
 import androidx.wear.tiles.ResourceBuilders.AndroidImageResourceByResId
 import androidx.wear.tiles.ResourceBuilders.ImageResource
 import androidx.wear.tiles.ResourceBuilders.Resources
 import androidx.wear.tiles.TileBuilders.Tile
+import androidx.wear.tiles.TileProviderService
 import androidx.wear.tiles.TimelineBuilders.Timeline
 import androidx.wear.tiles.TimelineBuilders.TimelineEntry
-import androidx.wear.tiles.RequestBuilders.ResourcesRequest
-import androidx.wear.tiles.RequestBuilders.TileRequest
 import com.example.wear.tiles.R
 import com.example.wear.tiles.components.IconButton
 import kotlinx.coroutines.CoroutineScope

--- a/WearTilesKotlin/app/src/main/java/com/example/wear/tiles/messaging/MessagingTileService.kt
+++ b/WearTilesKotlin/app/src/main/java/com/example/wear/tiles/messaging/MessagingTileService.kt
@@ -24,7 +24,6 @@ import android.graphics.Rect
 import android.graphics.drawable.BitmapDrawable
 import androidx.core.content.ContextCompat
 import androidx.wear.tiles.ActionBuilders
-import androidx.wear.tiles.TileProviderService
 import androidx.wear.tiles.ColorBuilders.argb
 import androidx.wear.tiles.DeviceParametersBuilders.DeviceParameters
 import androidx.wear.tiles.DimensionBuilders.dp
@@ -43,15 +42,17 @@ import androidx.wear.tiles.ModifiersBuilders.Clickable
 import androidx.wear.tiles.ModifiersBuilders.Corner
 import androidx.wear.tiles.ModifiersBuilders.Modifiers
 import androidx.wear.tiles.ModifiersBuilders.Semantics
+import androidx.wear.tiles.RequestBuilders.ResourcesRequest
+import androidx.wear.tiles.RequestBuilders.TileRequest
 import androidx.wear.tiles.ResourceBuilders
 import androidx.wear.tiles.ResourceBuilders.AndroidImageResourceByResId
 import androidx.wear.tiles.ResourceBuilders.ImageResource
 import androidx.wear.tiles.ResourceBuilders.InlineImageResource
 import androidx.wear.tiles.ResourceBuilders.Resources
 import androidx.wear.tiles.TileBuilders.Tile
+import androidx.wear.tiles.TileProviderService
 import androidx.wear.tiles.TimelineBuilders.Timeline
 import androidx.wear.tiles.TimelineBuilders.TimelineEntry
-import androidx.wear.tiles.RequestBuilders.*
 import com.example.wear.tiles.R
 import com.google.common.util.concurrent.ListenableFuture
 import kotlinx.coroutines.CoroutineScope

--- a/WearVerifyRemoteApp/Application/build.gradle
+++ b/WearVerifyRemoteApp/Application/build.gradle
@@ -20,13 +20,13 @@ plugins {
 }
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     defaultConfig {
         versionCode 1
         versionName "1.0"
         minSdkVersion 23
-        targetSdkVersion 30
+        targetSdkVersion 31
     }
 
     compileOptions {
@@ -46,12 +46,12 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.1"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.5.1"
-    implementation "androidx.activity:activity-ktx:1.2.3"
-    implementation 'androidx.appcompat:appcompat:1.3.0'
-    implementation "androidx.constraintlayout:constraintlayout:2.0.4"
+    implementation "androidx.activity:activity-ktx:1.3.1"
+    implementation 'androidx.appcompat:appcompat:1.3.1'
+    implementation "androidx.constraintlayout:constraintlayout:2.1.0"
     implementation "androidx.core:core-ktx:1.6.0"
-    implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.4.0-alpha02"
-    implementation 'androidx.wear:wear-remote-interactions:1.0.0-alpha05'
+    implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.4.0-alpha03"
+    implementation 'androidx.wear:wear-remote-interactions:1.0.0-alpha06'
     implementation 'com.google.android.gms:play-services-wearable:17.1.0'
 
     wearApp project(':Wearable')

--- a/WearVerifyRemoteApp/Application/src/main/AndroidManifest.xml
+++ b/WearVerifyRemoteApp/Application/src/main/AndroidManifest.xml
@@ -24,7 +24,9 @@
         android:icon="@mipmap/ic_launcher"
         android:theme="@style/AppThemeCustom">
 
-        <activity android:name=".MainMobileActivity">
+        <activity
+            android:name=".MainMobileActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>

--- a/WearVerifyRemoteApp/Application/src/main/java/com/example/android/wearable/wear/wearverifyremoteapp/MainMobileActivity.kt
+++ b/WearVerifyRemoteApp/Application/src/main/java/com/example/android/wearable/wear/wearverifyremoteapp/MainMobileActivity.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2016 Google Inc. All Rights Reserved.
+ * Copyright 2016 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/WearVerifyRemoteApp/Wearable/build.gradle
+++ b/WearVerifyRemoteApp/Wearable/build.gradle
@@ -29,6 +29,10 @@ android {
         targetSdkVersion 30
     }
 
+    lintOptions {
+        ignore "OldTargetApi" // API >30 doesn't exist for Wear OS
+    }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
@@ -46,11 +50,11 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.1"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.5.1"
-    implementation "androidx.activity:activity-ktx:1.2.3"
-    implementation "androidx.constraintlayout:constraintlayout:2.0.4"
+    implementation "androidx.activity:activity-ktx:1.3.1"
+    implementation "androidx.constraintlayout:constraintlayout:2.1.0"
     implementation "androidx.core:core-ktx:1.6.0"
-    implementation 'androidx.wear:wear:1.2.0-alpha12'
-    implementation 'androidx.wear:wear-phone-interactions:1.0.0-alpha06'
-    implementation 'androidx.wear:wear-remote-interactions:1.0.0-alpha05'
+    implementation 'androidx.wear:wear:1.2.0-alpha13'
+    implementation 'androidx.wear:wear-phone-interactions:1.0.0-alpha07'
+    implementation 'androidx.wear:wear-remote-interactions:1.0.0-alpha06'
     implementation 'com.google.android.gms:play-services-wearable:17.1.0'
 }

--- a/WearVerifyRemoteApp/Wearable/src/main/AndroidManifest.xml
+++ b/WearVerifyRemoteApp/Wearable/src/main/AndroidManifest.xml
@@ -31,7 +31,8 @@
 
         <activity
             android:name=".MainWearActivity"
-            android:label="@string/app_name">
+            android:label="@string/app_name"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/scripts/checksum.sh
+++ b/scripts/checksum.sh
@@ -36,5 +36,5 @@ done < <(find $SAMPLE -type f \( -name "build.gradle*" -o -name "gradle-wrapper.
 for FILE in ${FILES[@]}; do
 	echo $(checksum_file $FILE) >> $RESULT_FILE
 done
-# Now sort the file so that it is
+# Now sort the file so that it is idempotent
 sort $RESULT_FILE -o $RESULT_FILE

--- a/scripts/checksum.sh
+++ b/scripts/checksum.sh
@@ -1,0 +1,40 @@
+#
+#  Copyright 2021 Google, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+#!/bin/bash
+SAMPLE=$1
+RESULT_FILE=$2
+
+if [ -f $RESULT_FILE ]; then
+  rm $RESULT_FILE
+fi
+touch $RESULT_FILE
+
+checksum_file() {
+  echo $(openssl md5 $1 | awk '{print $2}')
+}
+
+FILES=()
+while read -r -d ''; do
+	FILES+=("$REPLY")
+done < <(find $SAMPLE -type f \( -name "build.gradle*" -o -name "gradle-wrapper.properties"  -o -name "robolectric.properties" \) -print0)
+
+# Loop through files and append MD5 to result file
+for FILE in ${FILES[@]}; do
+	echo $(checksum_file $FILE) >> $RESULT_FILE
+done
+# Now sort the file so that it is
+sort $RESULT_FILE -o $RESULT_FILE


### PR DESCRIPTION
Adds GitHub Actions CI for most of the projects in the repo, based on the CI for https://github.com/android/compose-samples. This runs `./gradlew check`, which includes `lint`, `spotless`, and in the future, any non-instrumented tests.

I attempted to use [`android-emulator-runner`](https://github.com/ReactiveCircus/android-emulator-runner) to run `AlwaysOnKotlin`'s instrumented tests on CI, but I have this disabled for now due to flakiness.