### PR TITLE
[VerifyRemote] Fix handling of CancellationExceptions

### DIFF
--- a/WearVerifyRemoteApp/Application/src/main/java/com/example/android/wearable/wear/wearverifyremoteapp/MainMobileActivity.kt
+++ b/WearVerifyRemoteApp/Application/src/main/java/com/example/android/wearable/wear/wearverifyremoteapp/MainMobileActivity.kt
@@ -133,6 +133,7 @@ class MainMobileActivity : AppCompatActivity(), OnCapabilityChangedListener {
             }
         } catch (cancellationException: CancellationException) {
             // Request was cancelled normally
+            throw cancellationException
         } catch (throwable: Throwable) {
             Log.d(TAG, "Capability request failed to return any results.")
         }

--- a/WearVerifyRemoteApp/Wearable/src/main/java/com/example/android/wearable/wear/wearverifyremoteapp/MainWearActivity.kt
+++ b/WearVerifyRemoteApp/Wearable/src/main/java/com/example/android/wearable/wear/wearverifyremoteapp/MainWearActivity.kt
@@ -177,6 +177,7 @@ class MainWearActivity : FragmentActivity(), CapabilityClient.OnCapabilityChange
                 ConfirmationOverlay().showOn(this@MainWearActivity)
             } catch (cancellationException: CancellationException) {
                 // Request was cancelled normally
+                throw cancellationException
             } catch (throwable: Throwable) {
                 ConfirmationOverlay()
                     .setType(ConfirmationOverlay.FAILURE_ANIMATION)


### PR DESCRIPTION
Fixes the handling of `CancellationException`s in `VerifyRemote`.

We still don't want to catch them in our `throwable: Throwable` block, but we also don't want to eat them. We should instead rethrow the exception again to allow cancellation to propogate.