### PR TITLE
Fix CustomTimeText visibility in preview

### DIFF
--- a/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/components/CustomTimeText.kt
+++ b/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/components/CustomTimeText.kt
@@ -76,7 +76,7 @@ fun CustomTimeText(
 @Composable
 fun PreviewCustomTimeText() {
     CustomTimeText(
-        visible = false,
+        visible = true,
         showLeadingText = true,
         leadingText = "Testing Leading Text..."
     )


### PR DESCRIPTION
Closes #164 

Fix CustomTimeText visibility in preview

Screenshot:
<img width="421" alt="Screenshot 2021-10-15 at 10 05 45 PM" src="https://user-images.githubusercontent.com/20878145/137523405-4c42cf16-58f7-4f22-9878-afce78ec6d85.png">

 