### PR TITLE
[AlwaysOn] Update dependencies

### DIFF
--- a/.github/workflows/AlwaysOnKotlin.yml
+++ b/.github/workflows/AlwaysOnKotlin.yml
@@ -55,7 +55,6 @@ jobs:
           path: ${{ env.SAMPLE_PATH }}/Wearable/build/reports
 
   android-test:
-    if: false # TODO: Try to enable and avoid flakiness
     needs: build
     runs-on: macOS-latest # enables hardware acceleration in the virtual machine
     timeout-minutes: 30
@@ -85,32 +84,12 @@ jobs:
             ~/.gradle/caches/build-cache-*
           key: gradle-${{ hashFiles('checksum.txt') }}
 
-      # android-emulator-runner currently doesn't support wear targets (https://github.com/ReactiveCircus/android-emulator-runner/issues/175)
-      # This is a bit if a weird workaround to still use the action, in a roundabout way.
-
-      # Setup the action with a fake emulator (downloads the cmdline-tools, etc.)
-      - name: Setup android-emulator-runner
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: ${{ matrix.api-level }}
-          target: google_apis
-          avd-name: fake
-          script: echo "Fake Android Emulator created"
-
-      # Manually download the Wear images that we need (--channel=1 is currently necessary for API 30 until it is released to the stable channel)
-      - name: Manually install Wear images
-        run: $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager --install 'system-images;android-${{ matrix.api-level }};android-wear;x86' --channel=1
-
-      # Manually create the Wear emulator, using the previously downloaded images
-      - name: Manually create Wear AVD
-        run: $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/avdmanager create avd --force -n "test" --abi 'android-wear/x86' --package 'system-images;android-${{ matrix.api-level }};android-wear;x86' -d ${{ matrix.profile }}
-
-      # Run the action again, but with force-avd-creation false. This skips some of the normal setup and validation, and uses the emulator we just created above.
       - name: Run instrumentation tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
-          target: google_apis
+          profile: ${{ matrix.profile }}
+          target: android-wear
           force-avd-creation: false
           avd-name: test
           disable-animations: true

--- a/AlwaysOnKotlin/Wearable/build.gradle
+++ b/AlwaysOnKotlin/Wearable/build.gradle
@@ -60,12 +60,12 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.1"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.2"
     implementation "androidx.activity:activity-ktx:1.3.1"
     implementation "androidx.core:core-ktx:1.6.0"
-    implementation 'androidx.wear:wear:1.2.0-beta01'
+    implementation 'androidx.wear:wear:1.2.0'
 
-    androidTestImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.5.1"
+    androidTestImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.5.2"
     androidTestImplementation "androidx.test:core:1.4.0"
     androidTestImplementation "androidx.test:core-ktx:1.4.0"
     androidTestImplementation "androidx.test.espresso:espresso-core:3.4.0"

--- a/AlwaysOnKotlin/Wearable/src/androidTest/java/com/example/android/wearable/wear/alwayson/MainActivityTests.kt
+++ b/AlwaysOnKotlin/Wearable/src/androidTest/java/com/example/android/wearable/wear/alwayson/MainActivityTests.kt
@@ -178,6 +178,7 @@ class MainActivityTests {
             ).send()
         }
 
+        Thread.sleep(1000) // Ugly sleep, without it sometimes the broadcast won't be received
         Espresso.onIdle()
 
         onView(withId(R.id.time)).check(matches(withText(TEN_SEC_DISPLAY)))

--- a/AlwaysOnKotlin/build.gradle
+++ b/AlwaysOnKotlin/build.gradle
@@ -15,14 +15,14 @@
  */
 
 buildscript {
-    ext.kotlin_version = "1.5.21"
+    ext.kotlin_version = "1.5.31"
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath "com.android.tools.build:gradle:7.0.0"
+        classpath "com.android.tools.build:gradle:7.0.3"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }


### PR DESCRIPTION
Updates dependencies for AlwaysOn, and also re-enables the integration tests on CI. I added another `Thread.sleep` to hopefully reduce the flakiness.