### PR TITLE
Set @Preview options for full page previews

### DIFF
--- a/AlwaysOnKotlin/compose/src/main/java/com/example/android/wearable/wear/alwayson/AlwaysOnScreen.kt
+++ b/AlwaysOnKotlin/compose/src/main/java/com/example/android/wearable/wear/alwayson/AlwaysOnScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Text
@@ -213,7 +214,7 @@ private tailrec fun Context.findActivity(): Activity =
         )
     }
 
-@Preview
+@Preview(device = Devices.WEAR_OS_SMALL_ROUND, showSystemUi = true)
 @Composable
 fun AlwaysOnScreenInteractivePreview() {
     MaterialTheme {
@@ -227,7 +228,7 @@ fun AlwaysOnScreenInteractivePreview() {
     }
 }
 
-@Preview
+@Preview(device = Devices.WEAR_OS_SMALL_ROUND, showSystemUi = true)
 @Composable
 fun AlwaysOnScreenAmbientPreview() {
     MaterialTheme {

--- a/ComposeStarter/app/src/main/java/com/example/android/wearable/composestarter/presentation/MainActivity.kt
+++ b/ComposeStarter/app/src/main/java/com/example/android/wearable/composestarter/presentation/MainActivity.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Text
@@ -85,9 +86,8 @@ fun Greeting(greetingName: String) {
     )
 }
 
-@Preview
+@Preview(device = Devices.WEAR_OS_SMALL_ROUND, showSystemUi = true)
 @Composable
-// Note: Preview in Android Studio doesn't support the round view yet (coming soon).
 fun DefaultPreview() {
     WearApp("Preview Android")
 }

--- a/DataLayer/Wearable/src/main/java/com/example/android/wearable/datalayer/MainApp.kt
+++ b/DataLayer/Wearable/src/main/java/com/example/android/wearable/datalayer/MainApp.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material.Button
@@ -145,7 +146,7 @@ fun MainApp(
     }
 }
 
-@Preview
+@Preview(device = Devices.WEAR_OS_SMALL_ROUND, showSystemUi = true)
 @Composable
 fun MainAppPreviewEvents() {
     MainApp(
@@ -183,7 +184,7 @@ fun MainAppPreviewEvents() {
     )
 }
 
-@Preview
+@Preview(device = Devices.WEAR_OS_SMALL_ROUND, showSystemUi = true)
 @Composable
 fun MainAppPreviewEmpty() {
     MainApp(

--- a/WearSpeakerSample/wear/src/main/java/com/example/android/wearable/speaker/SpeakerScreen.kt
+++ b/WearSpeakerSample/wear/src/main/java/com/example/android/wearable/speaker/SpeakerScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.datasource.CollectionPreviewParameterProvider
@@ -188,6 +189,8 @@ private class PlaybackStatePreviewProvider : CollectionPreviewParameterProvider<
 )
 
 @Preview(
+    device = Devices.WEAR_OS_SMALL_ROUND,
+    showSystemUi = true,
     widthDp = 200,
     heightDp = 200,
     uiMode = Configuration.UI_MODE_TYPE_WATCH,


### PR DESCRIPTION
Starting with Android Studio Dolphin, showSystemUi option controls if
the device frame/clip should be applied.