### PR TITLE
Add progress indicator examples to compose advanced

### DIFF
--- a/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/WearApp.kt
+++ b/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/WearApp.kt
@@ -68,6 +68,9 @@ import com.example.android.wearable.composeadvanced.presentation.ui.ScrollStateV
 import com.example.android.wearable.composeadvanced.presentation.ui.dialog.Dialogs
 import com.example.android.wearable.composeadvanced.presentation.ui.landing.LandingScreen
 import com.example.android.wearable.composeadvanced.presentation.ui.map.MapScreen
+import com.example.android.wearable.composeadvanced.presentation.ui.progressindicator.FullScreenProgressIndicator
+import com.example.android.wearable.composeadvanced.presentation.ui.progressindicator.IndeterminateProgressIndicator
+import com.example.android.wearable.composeadvanced.presentation.ui.progressindicator.ProgressIndicatorsScreen
 import com.example.android.wearable.composeadvanced.presentation.ui.userinput.SliderScreen
 import com.example.android.wearable.composeadvanced.presentation.ui.userinput.StepperScreen
 import com.example.android.wearable.composeadvanced.presentation.ui.userinput.UserInputComponentsScreen
@@ -151,6 +154,9 @@ fun WearApp(
                             Modifier.fadeAway {
                                 viewModel.scrollState
                             }
+                        }
+                        DestinationScrollType.TIME_TEXT_ONLY -> {
+                            Modifier
                         }
                         else -> {
                             null
@@ -239,6 +245,9 @@ fun WearApp(
                         onClickProceedingTimeText = {
                             showProceedingTextBeforeTime = !showProceedingTextBeforeTime
                         },
+                        onClickProgressIndicator = {
+                            swipeDismissableNavController.navigate(Screen.ProgressIndicators.route)
+                        }
                     )
 
                     RequestFocusOnResume(focusRequester)
@@ -278,7 +287,7 @@ fun WearApp(
                         },
                         onClickDemo24hTimePicker = {
                             swipeDismissableNavController.navigate(Screen.Time24hPicker.route)
-                        }
+                        },
                     )
 
                     RequestFocusOnResume(focusRequester)
@@ -434,6 +443,52 @@ fun WearApp(
 
                 composable(Screen.Dialogs.route) {
                     Dialogs()
+                }
+
+                composable(
+                    route = Screen.ProgressIndicators.route,
+                    arguments = listOf(
+                        // In this case, the argument isn't part of the route, it's just attached
+                        // as information for the destination.
+                        navArgument(SCROLL_TYPE_NAV_ARGUMENT) {
+                            type = NavType.EnumType(DestinationScrollType::class.java)
+                            defaultValue = DestinationScrollType.SCALING_LAZY_COLUMN_SCROLLING
+                        }
+                    )
+                ) {
+                    val scalingLazyListState = scalingLazyListState(it)
+
+                    val focusRequester = remember { FocusRequester() }
+
+                    ProgressIndicatorsScreen(
+                        scalingLazyListState = scalingLazyListState,
+                        focusRequester = focusRequester,
+                        onClickIndeterminateProgressIndicator = {
+                            swipeDismissableNavController.navigate(Screen.IndeterminateProgressIndicator.route)
+                        },
+                        onClickGapProgressIndicator = {
+                            swipeDismissableNavController.navigate(Screen.FullScreenProgressIndicator.route)
+                        }
+                    )
+                    RequestFocusOnResume(focusRequester)
+                }
+
+                composable(Screen.IndeterminateProgressIndicator.route) {
+                    IndeterminateProgressIndicator()
+                }
+
+                composable(
+                    route = Screen.FullScreenProgressIndicator.route,
+                    arguments = listOf(
+                        // In this case, the argument isn't part of the route, it's just attached
+                        // as information for the destination.
+                        navArgument(SCROLL_TYPE_NAV_ARGUMENT) {
+                            type = NavType.EnumType(DestinationScrollType::class.java)
+                            defaultValue = DestinationScrollType.TIME_TEXT_ONLY
+                        }
+                    )
+                ) {
+                    FullScreenProgressIndicator()
                 }
             }
         }

--- a/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/WearApp.kt
+++ b/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/WearApp.kt
@@ -464,10 +464,14 @@ fun WearApp(
                         scalingLazyListState = scalingLazyListState,
                         focusRequester = focusRequester,
                         onClickIndeterminateProgressIndicator = {
-                            swipeDismissableNavController.navigate(Screen.IndeterminateProgressIndicator.route)
+                            swipeDismissableNavController.navigate(
+                                Screen.IndeterminateProgressIndicator.route
+                            )
                         },
                         onClickGapProgressIndicator = {
-                            swipeDismissableNavController.navigate(Screen.FullScreenProgressIndicator.route)
+                            swipeDismissableNavController.navigate(
+                                Screen.FullScreenProgressIndicator.route
+                            )
                         }
                     )
                     RequestFocusOnResume(focusRequester)

--- a/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/navigation/DestinationScrollType.kt
+++ b/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/navigation/DestinationScrollType.kt
@@ -18,5 +18,6 @@ package com.example.android.wearable.composeadvanced.presentation.navigation
 enum class DestinationScrollType {
     NONE,
     COLUMN_SCROLLING,
-    SCALING_LAZY_COLUMN_SCROLLING
+    SCALING_LAZY_COLUMN_SCROLLING,
+    TIME_TEXT_ONLY
 }

--- a/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/navigation/Screen.kt
+++ b/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/navigation/Screen.kt
@@ -40,4 +40,7 @@ sealed class Screen(
     object Time12hPicker : Screen("time12h")
     object Time24hPicker : Screen("time24h")
     object Dialogs : Screen("dialogs")
+    object ProgressIndicators : Screen("progressIndicators")
+    object IndeterminateProgressIndicator : Screen("indeterminateProgressIndicator")
+    object FullScreenProgressIndicator : Screen("fullScreenProgressIndicator")
 }

--- a/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/ui/landing/LandingScreen.kt
+++ b/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/ui/landing/LandingScreen.kt
@@ -68,6 +68,7 @@ fun LandingScreen(
     onClickDemoUserInputComponents: () -> Unit,
     onClickDemoMap: () -> Unit,
     onClickDialogs: () -> Unit,
+    onClickProgressIndicator: () -> Unit,
     proceedingTimeTextEnabled: Boolean,
     onClickProceedingTimeText: (Boolean) -> Unit,
 ) {
@@ -118,13 +119,24 @@ fun LandingScreen(
                     }
                 )
             }
-
             item {
                 CompactChip(
                     onClick = onClickDialogs,
                     label = {
                         Text(
                             stringResource(R.string.dialogs_label),
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
+                )
+            }
+            item {
+                CompactChip(
+                    onClick = onClickProgressIndicator,
+                    label = {
+                        Text(
+                            stringResource(R.string.progress_indicators_label),
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis
                         )

--- a/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/ui/progressindicator/ProgressIndicators.kt
+++ b/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/ui/progressindicator/ProgressIndicators.kt
@@ -1,0 +1,99 @@
+package com.example.android.wearable.composeadvanced.presentation.ui.progressindicator
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.material.CircularProgressIndicator
+import androidx.wear.compose.material.CompactChip
+import androidx.wear.compose.material.ScalingLazyColumn
+import androidx.wear.compose.material.ScalingLazyListState
+import androidx.wear.compose.material.Text
+import com.example.android.wearable.composeadvanced.R
+import com.google.android.horologist.compose.navscaffold.ExperimentalComposeLayoutApi
+import com.google.android.horologist.compose.navscaffold.scrollableColumn
+
+@OptIn(ExperimentalComposeLayoutApi::class)
+@Composable
+fun ProgressIndicatorsScreen(
+    scalingLazyListState: ScalingLazyListState,
+    focusRequester: FocusRequester,
+    onClickIndeterminateProgressIndicator: () -> Unit,
+    onClickGapProgressIndicator: () -> Unit,
+) {
+    ScalingLazyColumn(
+        modifier = Modifier.scrollableColumn(focusRequester, scalingLazyListState),
+        state = scalingLazyListState
+    ) {
+        item {
+            CompactChip(
+                onClick = onClickIndeterminateProgressIndicator,
+                label = {
+                    Text(
+                        stringResource(R.string.indeterminate_progress_indicator_label),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                },
+            )
+        }
+        item {
+            CompactChip(
+                onClick = onClickGapProgressIndicator,
+                label = {
+                    Text(
+                        stringResource(R.string.full_screen_progress_indicator_label),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                },
+            )
+        }
+
+    }
+}
+
+@Composable
+fun IndeterminateProgressIndicator() {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        CircularProgressIndicator()
+    }
+}
+
+
+@Composable
+fun FullScreenProgressIndicator() {
+    val transition = rememberInfiniteTransition()
+
+    val currentRotation by transition.animateFloat(
+        0f,
+        1f,
+        infiniteRepeatable(
+            animation = tween(
+                durationMillis = 5000,
+                easing = LinearEasing,
+                delayMillis = 1000
+            )
+        )
+    )
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        CircularProgressIndicator(
+            startAngle = 315f,
+            endAngle = 225f,
+            progress = currentRotation,
+            modifier = Modifier.fillMaxSize().padding(all = 1.dp)
+        )
+    }
+}

--- a/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/ui/progressindicator/ProgressIndicators.kt
+++ b/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/ui/progressindicator/ProgressIndicators.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.example.android.wearable.composeadvanced.presentation.ui.progressindicator
 
 import androidx.compose.animation.core.LinearEasing

--- a/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/ui/progressindicator/ProgressIndicators.kt
+++ b/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/ui/progressindicator/ProgressIndicators.kt
@@ -76,7 +76,6 @@ fun ProgressIndicatorsScreen(
                 },
             )
         }
-
     }
 }
 
@@ -86,7 +85,6 @@ fun IndeterminateProgressIndicator() {
         CircularProgressIndicator()
     }
 }
-
 
 @Composable
 fun FullScreenProgressIndicator() {

--- a/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/ui/userinput/UserInputComponentsScreen.kt
+++ b/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/ui/userinput/UserInputComponentsScreen.kt
@@ -34,7 +34,7 @@ import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
 /**
- * Displays a value by using a Stepper or a Slider
+ * Shows different input options like Pickers, Steppers and Sliders
  */
 @Composable
 fun UserInputComponentsScreen(

--- a/ComposeAdvanced/app/src/main/res/values/strings.xml
+++ b/ComposeAdvanced/app/src/main/res/values/strings.xml
@@ -46,5 +46,8 @@
     <string name="confirmation_dialog_no">No</string>
     <string name="alert_dialog_yes">Yes</string>
     <string name="confirmation_dialog_success">Success</string>
+    <string name="progress_indicators_label">Progress Indicators</string>
+    <string name="indeterminate_progress_indicator_label">Indeterminate</string>
+    <string name="full_screen_progress_indicator_label">Full Screen with Gap</string>
 
 </resources>


### PR DESCRIPTION
Add an example of a spinner and a full screen progress indicator to the sample.
Add a new type of destination scroll type for time text only.
Fix up out of date comment in UserInputComponentsScreen.kt