### PR TITLE
Refactor Landingscreen

### DIFF
--- a/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/WearApp.kt
+++ b/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/WearApp.kt
@@ -226,28 +226,39 @@ fun WearApp(
 
                     val focusRequester = remember { FocusRequester() }
 
+                    val menuItemNameToClickHandlerMap = sortedMapOf(
+                        menuNameAndCallback(
+                            navController = swipeDismissableNavController,
+                            menuNameResource = R.string.user_input_components_label,
+                            screen = Screen.UserInputComponents
+                        ),
+                        menuNameAndCallback(
+                            navController = swipeDismissableNavController,
+                            menuNameResource = R.string.map_label,
+                            screen = Screen.Map
+                        ),
+                        menuNameAndCallback(
+                            navController = swipeDismissableNavController,
+                            menuNameResource = R.string.dialogs_label,
+                            screen = Screen.Dialogs
+                        ),
+                        menuNameAndCallback(
+                            navController = swipeDismissableNavController,
+                            menuNameResource = R.string.progress_indicators_label,
+                            screen = Screen.ProgressIndicators
+                        ),
+                    )
                     LandingScreen(
                         scalingLazyListState = scalingLazyListState,
                         focusRequester = focusRequester,
                         onClickWatchList = {
                             swipeDismissableNavController.navigate(Screen.WatchList.route)
                         },
-                        onClickDemoUserInputComponents = {
-                            swipeDismissableNavController.navigate(Screen.UserInputComponents.route)
-                        },
-                        onClickDemoMap = {
-                            swipeDismissableNavController.navigate(Screen.Map.route)
-                        },
-                        onClickDialogs = {
-                            swipeDismissableNavController.navigate(Screen.Dialogs.route)
-                        },
+                        menuItemNameToClickHandlerMap = menuItemNameToClickHandlerMap,
                         proceedingTimeTextEnabled = showProceedingTextBeforeTime,
                         onClickProceedingTimeText = {
                             showProceedingTextBeforeTime = !showProceedingTextBeforeTime
                         },
-                        onClickProgressIndicator = {
-                            swipeDismissableNavController.navigate(Screen.ProgressIndicators.route)
-                        }
                     )
 
                     RequestFocusOnResume(focusRequester)
@@ -498,6 +509,13 @@ fun WearApp(
         }
     }
 }
+
+@Composable
+private fun menuNameAndCallback(
+    navController: NavHostController,
+    menuNameResource: Int,
+    screen: Screen
+) = stringResource(menuNameResource) to { navController.navigate(screen.route) }
 
 @Composable
 private fun scrollState(it: NavBackStackEntry): ScrollState {

--- a/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/ui/landing/LandingScreen.kt
+++ b/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/ui/landing/LandingScreen.kt
@@ -70,10 +70,7 @@ fun LandingScreen(
     scalingLazyListState: ScalingLazyListState,
     focusRequester: FocusRequester,
     onClickWatchList: () -> Unit,
-    onClickDemoUserInputComponents: () -> Unit,
-    onClickDemoMap: () -> Unit,
-    onClickDialogs: () -> Unit,
-    onClickProgressIndicator: () -> Unit,
+    menuItemNameToClickHandlerMap: Map<String, () -> Unit>,
     proceedingTimeTextEnabled: Boolean,
     onClickProceedingTimeText: (Boolean) -> Unit,
 ) {
@@ -98,55 +95,19 @@ fun LandingScreen(
                     }
                 )
             }
-
-            item {
-                CompactChip(
-                    onClick = onClickDemoUserInputComponents,
-                    label = {
-                        Text(
-                            stringResource(R.string.user_input_components_label),
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis
-                        )
-                    }
-                )
-            }
-
-            item {
-                CompactChip(
-                    onClick = onClickDemoMap,
-                    label = {
-                        Text(
-                            stringResource(R.string.map_label),
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis
-                        )
-                    }
-                )
-            }
-            item {
-                CompactChip(
-                    onClick = onClickDialogs,
-                    label = {
-                        Text(
-                            stringResource(R.string.dialogs_label),
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis
-                        )
-                    }
-                )
-            }
-            item {
-                CompactChip(
-                    onClick = onClickProgressIndicator,
-                    label = {
-                        Text(
-                            stringResource(R.string.progress_indicators_label),
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis
-                        )
-                    }
-                )
+            for (mapItem in menuItemNameToClickHandlerMap) {
+                item {
+                    CompactChip(
+                        onClick = mapItem.value,
+                        label = {
+                            Text(
+                                mapItem.key,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                        }
+                    )
+                }
             }
             item {
                 ToggleChip(


### PR DESCRIPTION
Allow LandingScreen to take a map of menu item names to click handlers - before adding more items to the list I wanted to do a refactor and also check that folks are happy with this approach as I think we can apply it to some of the other menus as well.