### PR TITLE
Add an example of getting text input from a RemoteInputIntentHelper

### DIFF
--- a/ComposeAdvanced/app/build.gradle
+++ b/ComposeAdvanced/app/build.gradle
@@ -128,6 +128,7 @@ dependencies {
     // Horologist
     implementation libs.horologist.composables
     implementation libs.horologist.compose.layout
+    implementation 'androidx.wear:wear-input:1.1.0'
 
     // Testing
     testImplementation libs.junit

--- a/ComposeAdvanced/app/build.gradle
+++ b/ComposeAdvanced/app/build.gradle
@@ -128,7 +128,7 @@ dependencies {
     // Horologist
     implementation libs.horologist.composables
     implementation libs.horologist.compose.layout
-    implementation 'androidx.wear:wear-input:1.1.0'
+    implementation libs.wear.input
 
     // Testing
     testImplementation libs.junit

--- a/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/ui/userinput/UserInputComponentsScreen.kt
+++ b/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/ui/userinput/UserInputComponentsScreen.kt
@@ -20,6 +20,7 @@ package com.example.android.wearable.composeadvanced.presentation.ui.userinput
 import android.app.RemoteInput
 import android.content.Intent
 import android.os.Bundle
+import android.view.inputmethod.EditorInfo
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
@@ -36,6 +37,7 @@ import androidx.wear.compose.material.ScalingLazyColumn
 import androidx.wear.compose.material.ScalingLazyListState
 import androidx.wear.compose.material.Text
 import androidx.wear.input.RemoteInputIntentHelper
+import androidx.wear.input.wearableExtender
 import com.example.android.wearable.composeadvanced.R
 import com.google.android.horologist.compose.navscaffold.ExperimentalComposeLayoutApi
 import com.google.android.horologist.compose.navscaffold.scrollableColumn
@@ -166,18 +168,21 @@ fun UserInputComponentsScreen(
                         textForUserInput = newInputText as String
                     }
                 }
-            val label = stringResource(R.string.manual_text_entry_label)
+
+            val intent: Intent = RemoteInputIntentHelper.createActionRemoteInputIntent()
+            val remoteInputs: List<RemoteInput> = listOf(
+                RemoteInput.Builder("input_text")
+                    .setLabel(stringResource(R.string.manual_text_entry_label))
+                    .wearableExtender {
+                        setEmojisAllowed(true)
+                        setInputActionType(EditorInfo.IME_ACTION_DONE)
+                    }.build()
+            )
+
+            RemoteInputIntentHelper.putRemoteInputsExtra(intent, remoteInputs)
+
             Chip(
                 onClick = {
-                    val intent: Intent = RemoteInputIntentHelper.createActionRemoteInputIntent()
-                    val remoteInputs: List<RemoteInput> = listOf(
-                        RemoteInput.Builder("input_text")
-                            .setLabel(label)
-                            .build()
-                    )
-
-                    RemoteInputIntentHelper.putRemoteInputsExtra(intent, remoteInputs)
-
                     launcher.launch(intent)
                 },
                 label = {

--- a/ComposeAdvanced/app/src/main/res/values/strings.xml
+++ b/ComposeAdvanced/app/src/main/res/values/strings.xml
@@ -50,5 +50,7 @@
     <string name="progress_indicators_label">Progress Indicators</string>
     <string name="indeterminate_progress_indicator_label">Indeterminate</string>
     <string name="full_screen_progress_indicator_label">Full Screen with Gap</string>
+    <string name="text_input_label">Text Input</string>
+    <string name="manual_text_entry_label">Manual Text Entry</string>
 
 </resources>

--- a/ComposeAdvanced/gradle/libs.versions.toml
+++ b/ComposeAdvanced/gradle/libs.versions.toml
@@ -45,6 +45,7 @@ test-uiautomator = "androidx.test.uiautomator:uiautomator:2.2.0"
 wear-compose-foundation = { module = "androidx.wear.compose:compose-foundation", version.ref = "androidx-wear-compose" }
 wear-compose-material = { module = "androidx.wear.compose:compose-material", version.ref = "androidx-wear-compose" }
 wear-compose-navigation = { module = "androidx.wear.compose:compose-navigation", version.ref = "androidx-wear-compose" }
+wear-input = "androidx.wear:wear-input:1.1.0"
 
 [plugins]
 com-android-application = { id = "com.android.application", version.ref = "android-gradle-plugin" }

--- a/ComposeAdvanced/gradle/libs.versions.toml
+++ b/ComposeAdvanced/gradle/libs.versions.toml
@@ -45,7 +45,7 @@ test-uiautomator = "androidx.test.uiautomator:uiautomator:2.2.0"
 wear-compose-foundation = { module = "androidx.wear.compose:compose-foundation", version.ref = "androidx-wear-compose" }
 wear-compose-material = { module = "androidx.wear.compose:compose-material", version.ref = "androidx-wear-compose" }
 wear-compose-navigation = { module = "androidx.wear.compose:compose-navigation", version.ref = "androidx-wear-compose" }
-wear-input = "androidx.wear:wear-input:1.1.0"
+wear-input = "androidx.wear:wear-input:1.2.0-alpha02"
 
 [plugins]
 com-android-application = { id = "com.android.application", version.ref = "android-gradle-plugin" }


### PR DESCRIPTION
Provide an example of getting text input from the user using RemoteInputIntentHelper. At the moment this is the only reliable way of getting text input as there are known issues with the foundation compose BasicTextField

![Screenshot_20220506_135119](https://user-images.githubusercontent.com/8665763/167136667-549e16c2-bff1-4444-bb8b-9f53d5b4135c.png)

![Screenshot_20220506_135137](https://user-images.githubusercontent.com/8665763/167136682-fb77c816-e880-4ac2-865a-86d5a7f8e642.png)
.