### PR TITLE
Add dynamic/selectable theme support to the Advanced Compose add.

### DIFF
--- a/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/WearApp.kt
+++ b/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/WearApp.kt
@@ -64,6 +64,8 @@ import com.example.android.wearable.composeadvanced.presentation.navigation.SCRO
 import com.example.android.wearable.composeadvanced.presentation.navigation.Screen
 import com.example.android.wearable.composeadvanced.presentation.navigation.WATCH_ID_NAV_ARGUMENT
 import com.example.android.wearable.composeadvanced.presentation.theme.WearAppTheme
+import com.example.android.wearable.composeadvanced.presentation.theme.initialThemeValues
+import com.example.android.wearable.composeadvanced.presentation.theme.themeValues
 import com.example.android.wearable.composeadvanced.presentation.ui.ScalingLazyListStateViewModel
 import com.example.android.wearable.composeadvanced.presentation.ui.ScrollStateViewModel
 import com.example.android.wearable.composeadvanced.presentation.ui.dialog.Dialogs
@@ -72,6 +74,7 @@ import com.example.android.wearable.composeadvanced.presentation.ui.map.MapActiv
 import com.example.android.wearable.composeadvanced.presentation.ui.progressindicator.FullScreenProgressIndicator
 import com.example.android.wearable.composeadvanced.presentation.ui.progressindicator.IndeterminateProgressIndicator
 import com.example.android.wearable.composeadvanced.presentation.ui.progressindicator.ProgressIndicatorsScreen
+import com.example.android.wearable.composeadvanced.presentation.ui.theme.ThemeScreen
 import com.example.android.wearable.composeadvanced.presentation.ui.userinput.SliderScreen
 import com.example.android.wearable.composeadvanced.presentation.ui.userinput.StepperScreen
 import com.example.android.wearable.composeadvanced.presentation.ui.userinput.UserInputComponentsScreen
@@ -93,7 +96,8 @@ fun WearApp(
     swipeDismissableNavController: NavHostController = rememberSwipeDismissableNavController(),
     viewModelFactory: ViewModelProvider.Factory
 ) {
-    WearAppTheme {
+    var themeColors by remember { mutableStateOf(initialThemeValues.colors) }
+    WearAppTheme(colors = themeColors) {
         // Allows user to disable the text before the time.
         var showProceedingTextBeforeTime by rememberSaveable { mutableStateOf(false) }
 
@@ -247,6 +251,11 @@ fun WearApp(
                             navController = swipeDismissableNavController,
                             menuNameResource = R.string.progress_indicators_label,
                             screen = Screen.ProgressIndicators
+                        ),
+                        menuNameAndCallback(
+                            navController = swipeDismissableNavController,
+                            menuNameResource = R.string.theme_label,
+                            screen = Screen.Theme
                         ),
                     )
 
@@ -504,6 +513,29 @@ fun WearApp(
                     )
                 ) {
                     FullScreenProgressIndicator()
+                }
+
+                composable(
+                    route = Screen.Theme.route,
+                    arguments = listOf(
+                        // In this case, the argument isn't part of the route, it's just attached
+                        // as information for the destination.
+                        navArgument(SCROLL_TYPE_NAV_ARGUMENT) {
+                            type = NavType.EnumType(DestinationScrollType::class.java)
+                            defaultValue = DestinationScrollType.SCALING_LAZY_COLUMN_SCROLLING
+                        }
+                    )
+                ) { it ->
+                    val scalingLazyListState = scalingLazyListState(it)
+                    val focusRequester = remember { FocusRequester() }
+
+                    ThemeScreen(
+                        scalingLazyListState = scalingLazyListState,
+                        focusRequester = focusRequester,
+                        currentlySelectedColors = themeColors,
+                        availableThemes = themeValues
+                    ) { colors -> themeColors = colors }
+                    RequestFocusOnResume(focusRequester)
                 }
 
                 activity(

--- a/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/navigation/Screen.kt
+++ b/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/navigation/Screen.kt
@@ -43,4 +43,5 @@ sealed class Screen(
     object ProgressIndicators : Screen("progressIndicators")
     object IndeterminateProgressIndicator : Screen("indeterminateProgressIndicator")
     object FullScreenProgressIndicator : Screen("fullScreenProgressIndicator")
+    object Theme : Screen("theme")
 }

--- a/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/theme/Color.kt
+++ b/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/theme/Color.kt
@@ -18,22 +18,37 @@ package com.example.android.wearable.composeadvanced.presentation.theme
 import androidx.compose.ui.graphics.Color
 import androidx.wear.compose.material.Colors
 
-val Purple200 = Color(0xFFBB86FC)
-val Purple500 = Color(0xFF6200EE)
-val Purple700 = Color(0xFF3700B3)
-val Teal200 = Color(0xFF03DAC5)
-val Red400 = Color(0xFFCF6679)
+internal data class ThemeValues(val description: String, val colors: Colors)
 
-/**
- * Custom color palette for Wear App.
- */
-internal val wearColorPalette: Colors = Colors(
-    primary = Purple200,
-    primaryVariant = Purple700,
-    secondary = Teal200,
-    secondaryVariant = Teal200,
-    error = Red400,
-    onPrimary = Color.Black,
-    onSecondary = Color.Black,
-    onError = Color.Black
+internal val initialThemeValues = ThemeValues(
+    "Lilac (D0BCFF)",
+    Colors(
+        primary = Color(0xFFD0BCFF),
+        primaryVariant = Color(0xFF9A82DB),
+        secondary = Color(0xFF7FCFFF),
+        secondaryVariant = Color(0xFF3998D3)
+    )
+)
+
+internal val themeValues = listOf(
+    initialThemeValues,
+    ThemeValues("Blue (Default AECBFA)", Colors()),
+    ThemeValues(
+        "Blue 2 (7FCFFF)",
+        Colors(
+            primary = Color(0xFF7FCFFF),
+            primaryVariant = Color(0xFF3998D3),
+            secondary = Color(0xFF6DD58C),
+            secondaryVariant = Color(0xFF1EA446)
+        )
+    ),
+    ThemeValues(
+        "Green (6DD58C)",
+        Colors(
+            primary = Color(0xFF6DD58C),
+            primaryVariant = Color(0xFF1EA446),
+            secondary = Color(0xFFFFBB29),
+            secondaryVariant = Color(0xFFD68400)
+        )
+    ),
 )

--- a/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/theme/Theme.kt
+++ b/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/theme/Theme.kt
@@ -16,6 +16,7 @@
 package com.example.android.wearable.composeadvanced.presentation.theme
 
 import androidx.compose.runtime.Composable
+import androidx.wear.compose.material.Colors
 import androidx.wear.compose.material.MaterialTheme
 
 /**
@@ -23,10 +24,11 @@ import androidx.wear.compose.material.MaterialTheme
  */
 @Composable
 fun WearAppTheme(
+    colors: Colors = initialThemeValues.colors,
     content: @Composable () -> Unit
 ) {
     MaterialTheme(
-        colors = wearColorPalette,
+        colors = colors,
         typography = WearTypography,
         // For shapes, we generally recommend using the default Material Wear shapes which are
         // optimized for round and non-round devices.

--- a/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/ui/theme/ThemeScreen.kt
+++ b/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/ui/theme/ThemeScreen.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.android.wearable.composeadvanced.presentation.ui.theme
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.wear.compose.material.Colors
+import androidx.wear.compose.material.Icon
+import androidx.wear.compose.material.ListHeader
+import androidx.wear.compose.material.ScalingLazyColumn
+import androidx.wear.compose.material.ScalingLazyListState
+import androidx.wear.compose.material.Text
+import androidx.wear.compose.material.ToggleChip
+import androidx.wear.compose.material.ToggleChipDefaults
+import com.example.android.wearable.composeadvanced.presentation.theme.ThemeValues
+import com.google.android.horologist.compose.navscaffold.ExperimentalComposeLayoutApi
+import com.google.android.horologist.compose.navscaffold.scrollableColumn
+
+@OptIn(ExperimentalComposeLayoutApi::class)
+@Composable
+internal fun ThemeScreen(
+    scalingLazyListState: ScalingLazyListState,
+    focusRequester: FocusRequester,
+    currentlySelectedColors: Colors,
+    availableThemes: List<ThemeValues>,
+    onValueChange: (Colors) -> Unit
+) {
+    ScalingLazyColumn(
+        modifier = Modifier.scrollableColumn(focusRequester, scalingLazyListState),
+        state = scalingLazyListState,
+    ) {
+        item {
+            ListHeader {
+                Text("Color Schemes")
+            }
+        }
+        for (listItem in availableThemes) {
+            val checked = listItem.colors == currentlySelectedColors
+            item {
+                ToggleChip(
+                    checked = checked,
+                    toggleControl = {
+                        Icon(
+                            imageVector = ToggleChipDefaults.radioIcon(checked = checked),
+                            contentDescription = if (checked) "On" else "Off",
+                        )
+                    },
+                    onCheckedChange = { onValueChange(listItem.colors) },
+                    // Override the default toggle control color to show the user the current
+                    // primary selected color.
+                    colors = ToggleChipDefaults.toggleChipColors(
+                        checkedToggleControlColor = currentlySelectedColors.primary
+                    ),
+                    label = {
+                        Text(listItem.description)
+                    },
+                )
+            }
+        }
+    }
+}

--- a/ComposeAdvanced/app/src/main/res/values/strings.xml
+++ b/ComposeAdvanced/app/src/main/res/values/strings.xml
@@ -52,5 +52,6 @@
     <string name="full_screen_progress_indicator_label">Full Screen with Gap</string>
     <string name="text_input_label">Text Input</string>
     <string name="manual_text_entry_label">Manual Text Entry</string>
+    <string name="theme_label">Theme</string>
 
 </resources>


### PR DESCRIPTION
Give the user access to 4 different theme alternatives and a way to select them in the app

![Screenshot_20220509_185158](https://user-images.githubusercontent.com/8665763/167468470-fb880205-ebd5-436b-87fa-bc49f13e2f28.png)


![Screenshot_20220509_185116](https://user-images.githubusercontent.com/8665763/167468438-fcd75b41-3c58-44d9-9473-2924d7b9802c.png)
.