### PR TITLE
Apply explicit .fillMaxWidth to Chip/CompactChip and ToggleChips used…

### DIFF
--- a/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/components/WatchAppChip.kt
+++ b/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/components/WatchAppChip.kt
@@ -17,6 +17,7 @@ package com.example.android.wearable.composeadvanced.presentation.components
 
 import android.content.res.Configuration
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.runtime.Composable
@@ -44,7 +45,7 @@ fun WatchAppChip(
     modifier: Modifier = Modifier,
 ) {
     Chip(
-        modifier = modifier,
+        modifier = modifier.fillMaxWidth(),
         icon = {
             Icon(
                 painter = painterResource(id = watchIcon),

--- a/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/ui/dialog/DialogsScreen.kt
+++ b/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/ui/dialog/DialogsScreen.kt
@@ -15,6 +15,7 @@
  */
 package com.example.android.wearable.composeadvanced.presentation.ui.dialog
 
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
@@ -68,7 +69,8 @@ fun Dialogs(
                 },
                 colors = ChipDefaults.primaryChipColors(),
                 label = { Text(stringResource(R.string.confirmation_dialog_label)) },
-                secondaryLabel = { Text(confirmationStatus) }
+                secondaryLabel = { Text(confirmationStatus) },
+                modifier = Modifier.fillMaxWidth()
             )
         }
         item {
@@ -79,7 +81,8 @@ fun Dialogs(
                 },
                 colors = ChipDefaults.primaryChipColors(),
                 label = { Text(stringResource(R.string.alert_dialog_label)) },
-                secondaryLabel = { Text(alertStatus) }
+                secondaryLabel = { Text(alertStatus) },
+                modifier = Modifier.fillMaxWidth()
             )
         }
     }

--- a/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/ui/landing/LandingScreen.kt
+++ b/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/ui/landing/LandingScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
@@ -91,7 +92,8 @@ fun LandingScreen(
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis
                         )
-                    }
+                    },
+                    modifier = Modifier.fillMaxWidth()
                 )
             }
             for (listItem in menuItems) {
@@ -104,13 +106,14 @@ fun LandingScreen(
                                 maxLines = 1,
                                 overflow = TextOverflow.Ellipsis
                             )
-                        }
+                        },
+                        modifier = Modifier.fillMaxWidth()
                     )
                 }
             }
             item {
                 ToggleChip(
-                    modifier = Modifier.height(32.dp),
+                    modifier = Modifier.height(32.dp).fillMaxWidth(),
                     checked = proceedingTimeTextEnabled,
                     onCheckedChange = onClickProceedingTimeText,
                     label = {

--- a/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/ui/progressindicator/ProgressIndicators.kt
+++ b/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/ui/progressindicator/ProgressIndicators.kt
@@ -22,6 +22,7 @@ import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -62,6 +63,7 @@ fun ProgressIndicatorsScreen(
                             overflow = TextOverflow.Ellipsis
                         )
                     },
+                    modifier = Modifier.fillMaxWidth()
                 )
             }
         }

--- a/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/ui/theme/ThemeScreen.kt
+++ b/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/ui/theme/ThemeScreen.kt
@@ -15,6 +15,7 @@
  */
 package com.example.android.wearable.composeadvanced.presentation.ui.theme
 
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
@@ -68,6 +69,7 @@ internal fun ThemeScreen(
                     label = {
                         Text(listItem.description)
                     },
+                    modifier = Modifier.fillMaxWidth()
                 )
             }
         }

--- a/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/ui/userinput/UserInputComponentsScreen.kt
+++ b/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/ui/userinput/UserInputComponentsScreen.kt
@@ -22,6 +22,7 @@ import android.speech.RecognizerIntent
 import android.view.inputmethod.EditorInfo
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -102,7 +103,8 @@ fun UserInputComponentsScreen(
                     Text(
                         text = value.toString(),
                     )
-                }
+                },
+                modifier = Modifier.fillMaxWidth()
             )
         }
 
@@ -120,7 +122,8 @@ fun UserInputComponentsScreen(
                     Text(
                         text = value.toString(),
                     )
-                }
+                },
+                modifier = Modifier.fillMaxWidth()
             )
         }
 
@@ -138,7 +141,8 @@ fun UserInputComponentsScreen(
                     Text(
                         text = dateTime.toLocalDate().toString(),
                     )
-                }
+                },
+                modifier = Modifier.fillMaxWidth()
             )
         }
 
@@ -157,7 +161,8 @@ fun UserInputComponentsScreen(
                     Text(
                         text = dateTime.toLocalTime().format(formatter),
                     )
-                }
+                },
+                modifier = Modifier.fillMaxWidth()
             )
         }
 
@@ -176,7 +181,8 @@ fun UserInputComponentsScreen(
                     Text(
                         text = dateTime.toLocalTime().format(formatter),
                     )
-                }
+                },
+                modifier = Modifier.fillMaxWidth()
             )
         }
 
@@ -208,7 +214,8 @@ fun UserInputComponentsScreen(
                     Text(
                         text = textForUserInput,
                     )
-                }
+                },
+                modifier = Modifier.fillMaxWidth()
             )
         }
 
@@ -240,7 +247,8 @@ fun UserInputComponentsScreen(
                     Text(
                         text = textForVoiceInput,
                     )
-                }
+                },
+                modifier = Modifier.fillMaxWidth()
             )
         }
     }


### PR DESCRIPTION
… as menu items

In preparation for the changes to Chip sizing behavior in Compose for Wear OS Beta02 explicitly set fillMaxWidth() where needed on Chips used in full screen menu lists.