### PR TITLE
Fix for Android13 compatibility issue (#435)

### DIFF
--- a/RuntimePermissionsWear/Application/build.gradle
+++ b/RuntimePermissionsWear/Application/build.gradle
@@ -28,7 +28,7 @@ android {
         versionCode 1
         versionName "1.0"
         minSdkVersion 18
-        targetSdk 32
+        targetSdk 33
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/RuntimePermissionsWear/gradle/libs.versions.toml
+++ b/RuntimePermissionsWear/gradle/libs.versions.toml
@@ -25,7 +25,7 @@ kotlin-scripting-compiler-embeddable = { module = "org.jetbrains.kotlin:kotlin-s
 kotlin-stdlib-jdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "org-jetbrains-kotlin" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "org-jetbrains-kotlinx" }
 kotlinx-coroutines-play-services = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-play-services", version.ref = "org-jetbrains-kotlinx" }
-playservices-wearable = "com.google.android.gms:play-services-wearable:17.1.0"
+playservices-wearable = "com.google.android.gms:play-services-wearable:18.0.0"
 
 [plugins]
 com-android-application = { id = "com.android.application", version.ref = "android-gradle-plugin" }


### PR DESCRIPTION
- Bump targetSDK to 33
- Use newer version of play-services-wearable library with added support for apps targeting Android13