### PR TITLE
[DataLayer] Make use of defined constants

### DIFF
--- a/DataLayer/Wearable/src/main/java/com/example/android/wearable/datalayer/MainActivity.kt
+++ b/DataLayer/Wearable/src/main/java/com/example/android/wearable/datalayer/MainActivity.kt
@@ -55,7 +55,7 @@ class MainActivity : ComponentActivity() {
         lifecycleScope.launch {
             try {
                 val nodes = getCapabilitiesForReachableNodes()
-                    .filterValues { "mobile" in it || "wear" in it }.keys
+                    .filterValues { MOBILE_CAPABILITY in it || WEAR_CAPABILITY in it }.keys
                 displayNodes(nodes)
             } catch (cancellationException: CancellationException) {
                 throw cancellationException
@@ -69,7 +69,7 @@ class MainActivity : ComponentActivity() {
         lifecycleScope.launch {
             try {
                 val nodes = getCapabilitiesForReachableNodes()
-                    .filterValues { "mobile" in it && "camera" in it }.keys
+                    .filterValues { MOBILE_CAPABILITY in it && CAMERA_CAPABILITY in it }.keys
                 displayNodes(nodes)
             } catch (cancellationException: CancellationException) {
                 throw cancellationException


### PR DESCRIPTION
#### WHAT

Change `MainActivity` in `Wearable` app of `DataLayer` project to make use of the [defined constants](https://github.com/android/wear-os-samples/blob/5e3c9971097fb212c40a4bfae2a567bd8afc8791/DataLayer/Wearable/src/main/java/com/example/android/wearable/datalayer/MainActivity.kt#L136-L138) in the class.

#### WHY

In order to improve readability.

This was probably the intention when the constants were introduced in https://github.com/android/wear-os-samples/pull/200.

