### PR TITLE
#585 Remove dependency with wearApp configuration

### DIFF
--- a/DataLayer/Application/build.gradle
+++ b/DataLayer/Application/build.gradle
@@ -71,6 +71,4 @@ dependencies {
     implementation libs.androidx.lifecycle.viewmodel.compose
     implementation libs.androidx.lifecycle.runtime.ktx
     implementation libs.playservices.wearable
-
-    wearApp projects.wearable
 }


### PR DESCRIPTION
#### WHAT

Remove from the mobile app module, the dependency on the wear app module with `wearApp` configuration.

#### WHY

It does seem to be needed. Tested the app without it and it works fine.

The only place in the [documentation](https://developer.android.com/studio/build/dependencies#wear_apps) that I could find reference to this configuration seems to not explain why it is needed.

Related: #585 