### PR TITLE
Remove dependency with wearApp configuration

### DIFF
--- a/WearVerifyRemoteApp/Application/build.gradle
+++ b/WearVerifyRemoteApp/Application/build.gradle
@@ -53,6 +53,4 @@ dependencies {
     implementation libs.androidx.lifecycle.runtime.ktx
     implementation libs.wear.remote.interactions
     implementation libs.playservices.wearable
-
-    wearApp projects.wearable
 }


### PR DESCRIPTION
#### WHAT

Remove from the mobile app module of the `WearVerifyRemoteApp` sample, the dependency on the wear app module with `wearApp` configuration.

#### WHY

It does seem to be needed. Tested the app without it and it works fine.

The only place in the [documentation](https://developer.android.com/studio/build/dependencies#wear_apps) that I could find reference to this configuration seems to not explain why it is needed.

Related: #585 