### PR TITLE
[WearVerifyRemoteApp] Remove unused code

### DIFF
--- a/WearVerifyRemoteApp/Wearable/src/main/java/com/example/android/wearable/wear/wearverifyremoteapp/MainWearActivity.kt
+++ b/WearVerifyRemoteApp/Wearable/src/main/java/com/example/android/wearable/wear/wearverifyremoteapp/MainWearActivity.kt
@@ -32,7 +32,6 @@ import com.example.android.wearable.wear.wearverifyremoteapp.databinding.Activit
 import com.google.android.gms.wearable.CapabilityClient
 import com.google.android.gms.wearable.CapabilityInfo
 import com.google.android.gms.wearable.Node
-import com.google.android.gms.wearable.NodeClient
 import com.google.android.gms.wearable.Wearable
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
@@ -51,7 +50,6 @@ class MainWearActivity : FragmentActivity(), CapabilityClient.OnCapabilityChange
     private lateinit var binding: ActivityMainBinding
 
     private lateinit var capabilityClient: CapabilityClient
-    private lateinit var nodeClient: NodeClient
     private lateinit var remoteActivityHelper: RemoteActivityHelper
 
     private var androidPhoneNodeWithApp: Node? = null
@@ -63,7 +61,6 @@ class MainWearActivity : FragmentActivity(), CapabilityClient.OnCapabilityChange
         setContentView(binding.root)
 
         capabilityClient = Wearable.getCapabilityClient(this)
-        nodeClient = Wearable.getNodeClient(this)
         remoteActivityHelper = RemoteActivityHelper(this)
 
         binding.informationTextView.text = getString(R.string.message_checking)
@@ -156,6 +153,7 @@ class MainWearActivity : FragmentActivity(), CapabilityClient.OnCapabilityChange
                     .addCategory(Intent.CATEGORY_BROWSABLE)
                     .setData(Uri.parse(ANDROID_MARKET_APP_URI))
             }
+
             PhoneTypeHelper.DEVICE_TYPE_IOS -> {
                 Log.d(TAG, "\tDEVICE_TYPE_IOS")
 
@@ -164,6 +162,7 @@ class MainWearActivity : FragmentActivity(), CapabilityClient.OnCapabilityChange
                     .addCategory(Intent.CATEGORY_BROWSABLE)
                     .setData(Uri.parse(APP_STORE_APP_URI))
             }
+
             else -> {
                 Log.d(TAG, "\tDEVICE_TYPE_ERROR_UNKNOWN")
                 return


### PR DESCRIPTION
#### WHAT

Remove unused code from `MainWearActivity`.

Somehow related: https://github.com/android/wear-os-samples/issues/505

