### PR TITLE
[WearStandaloneGoogleSignIn] Update support topic in README

### DIFF
--- a/WearStandaloneGoogleSignIn/README.md
+++ b/WearStandaloneGoogleSignIn/README.md
@@ -16,8 +16,7 @@ adjust them according to your environment.
 Support
 -------
 
-You can find support by posting up on the Android Wear Developers Community
-page at the link below:
+- Stack Overflow: http://stackoverflow.com/questions/tagged/android
 
 If you've found an error in the sample, please file an issue report at:
 https://github.com/android/wear-os-samples/issues/new
@@ -27,8 +26,6 @@ Getting Started
 
 This sample uses the Gradle build system. To build this project, use the
 "gradlew build" command or use "Import Project" in Android Studio.
-
-- Stack Overflow: http://stackoverflow.com/questions/tagged/android
 
 Patches are encouraged, and may be submitted by forking this project and
 submitting a pull request through GitHub. Please see CONTRIBUTING.md for more details.


### PR DESCRIPTION
#### WHAT

Update support topic in README of `WearStandaloneGoogleSignIn` module.

#### WHY

Based on this blog [post](https://android-developers.googleblog.com/2017/01/final-android-wear-20-developer-preview.html) from 2017, it looks like "Android Wear Developers Community" was a Google plus [community](https://plus.google.com/communities/113381227473021565406) which is no longer.

Other [samples](https://github.com/android/wear-os-samples/blob/34959564394966395ccd2c6c174e6612c2adac96/AlwaysOnKotlin/README.md?plain=1#L50) have SO as support.
 

