### PR TITLE
Fix ExpiredTargetSdkVersion lint error

### DIFF
--- a/TimeText/gradle.properties
+++ b/TimeText/gradle.properties
@@ -12,6 +12,9 @@
 # Default value: -Xmx10248m -XX:MaxPermSize=256m
 # org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 
+# Increase memory
+org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=1596m -XX:+HeapDumpOnOutOfMemoryError
+
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects

--- a/TimeText/timetext/src/main/AndroidManifest.xml
+++ b/TimeText/timetext/src/main/AndroidManifest.xml
@@ -14,4 +14,8 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<manifest package="com.example.android.wearable.timetext" />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.android.wearable.timetext">
+
+    <uses-feature android:name="android.hardware.type.watch" />
+</manifest>

--- a/TimeText/timetexttestsupport/build.gradle
+++ b/TimeText/timetexttestsupport/build.gradle
@@ -24,7 +24,7 @@ android {
 
     defaultConfig {
         minSdk 23
-        targetSdk 30
+        targetSdk 33
     }
 
     lintOptions {

--- a/WearOAuth/util/build.gradle
+++ b/WearOAuth/util/build.gradle
@@ -23,7 +23,7 @@ android {
 
     defaultConfig {
         minSdk 23
-        targetSdk 30
+        targetSdk 33
         versionCode 1
         versionName "1.0"
 


### PR DESCRIPTION
#### WHAT

Fix/Ignore `ExpiredTargetSdkVersion` lint error.

#### WHY

Fixes #602 

#### HOW

- Add `android.hardware.type.watch` to `TimeText` as it seems to be a wear specific module;
- Bump `targetSdk` to 31 for `WearOAuth/util` and `TimeText/timetexttestsupport` as they seem to be a non-wear specific modules;
- Increase memory in `gradle.properties` from `TimeText` due to issue in CI when running `:wear:lintAnalyzeDebug`:
```
* Exception is:
java.lang.OutOfMemoryError: Metaspace
```
