### PR TITLE
Use animated toggle controls in ToggleChips

### DIFF
--- a/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/benchmark/ScrollActivity.kt
+++ b/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/benchmark/ScrollActivity.kt
@@ -98,7 +98,7 @@ fun SomeScreenContent() {
                         checked = itemChecked,
                         modifier = Modifier.semantics {
                             this.contentDescription =
-                                "Item $item ${if (itemChecked) "Checked" else "Unchecked"}"
+                                if (itemChecked) "Checked" else "Unchecked"
                         }
                     )
                 }

--- a/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/benchmark/ScrollActivity.kt
+++ b/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/benchmark/ScrollActivity.kt
@@ -28,11 +28,10 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.navigation.NavHostController
-import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.ScalingLazyColumn
+import androidx.wear.compose.material.Switch
 import androidx.wear.compose.material.Text
 import androidx.wear.compose.material.ToggleChip
-import androidx.wear.compose.material.ToggleChipDefaults
 import androidx.wear.compose.navigation.rememberSwipeDismissableNavController
 import com.example.android.wearable.composeadvanced.util.JankPrinter
 
@@ -95,9 +94,12 @@ fun SomeScreenContent() {
                     Text("Item $item")
                 },
                 toggleControl = {
-                    Icon(
-                        imageVector = ToggleChipDefaults.switchIcon(checked = itemChecked),
-                        contentDescription = "Item $item ${if (itemChecked) "Checked" else "Unchecked"}"
+                    Switch(
+                        checked = itemChecked,
+                        modifier = Modifier.semantics {
+                            this.contentDescription =
+                                "Item $item ${if (itemChecked) "Checked" else "Unchecked"}"
+                        }
                     )
                 }
             )

--- a/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/WearApp.kt
+++ b/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/WearApp.kt
@@ -75,8 +75,7 @@ import com.example.android.wearable.composeadvanced.presentation.ui.watchlist.Wa
 import com.google.android.horologist.composables.DatePicker
 import com.google.android.horologist.composables.TimePicker
 import com.google.android.horologist.composables.TimePickerWith12HourClock
-import com.google.android.horologist.compose.layout.fadeAway
-import com.google.android.horologist.compose.layout.fadeAwayScalingLazyList
+import com.google.android.horologist.compose.layout.scrollAway
 import java.time.LocalDateTime
 
 @Composable
@@ -138,20 +137,19 @@ fun WearApp(
                         DestinationScrollType.SCALING_LAZY_COLUMN_SCROLLING -> {
                             val scrollViewModel: ScalingLazyListStateViewModel =
                                 viewModel(currentBackStackEntry!!)
-                            Modifier.fadeAwayScalingLazyList {
-                                scrollViewModel.scrollState
-                            }
+                            Modifier.scrollAway(scrollViewModel.scrollState)
                         }
+
                         DestinationScrollType.COLUMN_SCROLLING -> {
                             val viewModel: ScrollStateViewModel =
                                 viewModel(currentBackStackEntry!!)
-                            Modifier.fadeAway {
-                                viewModel.scrollState
-                            }
+                            Modifier.scrollAway(viewModel.scrollState)
                         }
+
                         DestinationScrollType.TIME_TEXT_ONLY -> {
                             Modifier
                         }
+
                         else -> {
                             null
                         }
@@ -188,6 +186,7 @@ fun WearApp(
                             viewModel(currentBackStackEntry!!)
                         PositionIndicator(scalingLazyListState = scrollViewModel.scrollState)
                     }
+
                     DestinationScrollType.COLUMN_SCROLLING -> {
                         // Get or create the ViewModel associated with the current back stack entry
                         val viewModel: ScrollStateViewModel = viewModel(currentBackStackEntry!!)

--- a/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/ui/landing/LandingScreen.kt
+++ b/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/ui/landing/LandingScreen.kt
@@ -30,6 +30,8 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -43,13 +45,12 @@ import androidx.wear.compose.foundation.curvedRow
 import androidx.wear.compose.foundation.radialGradientBackground
 import androidx.wear.compose.material.AutoCenteringParams
 import androidx.wear.compose.material.Chip
-import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.ScalingLazyColumn
 import androidx.wear.compose.material.ScalingLazyListState
+import androidx.wear.compose.material.Switch
 import androidx.wear.compose.material.Text
 import androidx.wear.compose.material.ToggleChip
-import androidx.wear.compose.material.ToggleChipDefaults
 import androidx.wear.compose.material.curvedText
 import com.example.android.wearable.composeadvanced.R
 import com.example.android.wearable.composeadvanced.presentation.MenuItem
@@ -125,11 +126,12 @@ fun LandingScreen(
                         )
                     },
                     toggleControl = {
-                        Icon(
-                            imageVector = ToggleChipDefaults.switchIcon(
-                                checked = proceedingTimeTextEnabled
-                            ),
-                            contentDescription = if (proceedingTimeTextEnabled) "On" else "Off"
+                        Switch(
+                            checked = proceedingTimeTextEnabled,
+                            modifier = Modifier.semantics {
+                                this.contentDescription =
+                                    if (proceedingTimeTextEnabled) "On" else "Off"
+                            }
                         )
                     }
                 )

--- a/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/ui/theme/ThemeScreen.kt
+++ b/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/ui/theme/ThemeScreen.kt
@@ -19,19 +19,19 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.wear.compose.material.Colors
-import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.ListHeader
+import androidx.wear.compose.material.RadioButton
 import androidx.wear.compose.material.ScalingLazyColumn
 import androidx.wear.compose.material.ScalingLazyListState
 import androidx.wear.compose.material.Text
 import androidx.wear.compose.material.ToggleChip
 import androidx.wear.compose.material.ToggleChipDefaults
 import com.example.android.wearable.composeadvanced.presentation.theme.ThemeValues
-import com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi
 import com.google.android.horologist.compose.navscaffold.scrollableColumn
 
-@OptIn(ExperimentalHorologistComposeLayoutApi::class)
 @Composable
 internal fun ThemeScreen(
     scalingLazyListState: ScalingLazyListState,
@@ -55,9 +55,11 @@ internal fun ThemeScreen(
                 ToggleChip(
                     checked = checked,
                     toggleControl = {
-                        Icon(
-                            imageVector = ToggleChipDefaults.radioIcon(checked = checked),
-                            contentDescription = if (checked) "On" else "Off"
+                        RadioButton(
+                            selected = checked,
+                            modifier = Modifier.semantics {
+                                this.contentDescription = if (checked) "On" else "Off"
+                            }
                         )
                     },
                     onCheckedChange = { onValueChange(listItem.colors) },

--- a/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/ui/watchlist/WatchListScreen.kt
+++ b/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/ui/watchlist/WatchListScreen.kt
@@ -24,15 +24,16 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.ScalingLazyColumn
 import androidx.wear.compose.material.ScalingLazyListState
+import androidx.wear.compose.material.Switch
 import androidx.wear.compose.material.Text
 import androidx.wear.compose.material.ToggleChip
-import androidx.wear.compose.material.ToggleChipDefaults
 import androidx.wear.compose.material.items
 import com.example.android.wearable.composeadvanced.R
 import com.example.android.wearable.composeadvanced.data.WatchModel
@@ -100,9 +101,11 @@ fun WatchListScreen(
                     )
                 },
                 toggleControl = {
-                    Icon(
-                        imageVector = ToggleChipDefaults.switchIcon(checked = showVignette),
-                        contentDescription = if (showVignette) "On" else "Off"
+                    Switch(
+                        checked = showVignette,
+                        modifier = Modifier.semantics {
+                            this.contentDescription = if (showVignette) "On" else "Off"
+                        }
                     )
                 }
             )


### PR DESCRIPTION
In v1.1 `ToggleChip` support usage of animated toggle controls (`Checkbox`, `Switch` and `RadioButton`) that can be used instead of the static icons provided by `ToggleChipDefaults`.