### PR TITLE
Demos for Outlined style for Chips and modifying Chip shape

### DIFF
--- a/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/ui/dialog/Dialogs.kt
+++ b/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/ui/dialog/Dialogs.kt
@@ -31,10 +31,9 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material.Button
 import androidx.wear.compose.material.ButtonDefaults
-import androidx.wear.compose.material.Chip
-import androidx.wear.compose.material.ChipDefaults
 import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.MaterialTheme
+import androidx.wear.compose.material.OutlinedChip
 import androidx.wear.compose.material.ScalingLazyColumn
 import androidx.wear.compose.material.ScalingLazyListAnchorType
 import androidx.wear.compose.material.Text
@@ -62,24 +61,22 @@ fun Dialogs(
         anchorType = ScalingLazyListAnchorType.ItemStart
     ) {
         item {
-            Chip(
+            OutlinedChip(
                 onClick = {
                     confirmationStatus = ""
                     confirmationShowDialog = true
                 },
-                colors = ChipDefaults.primaryChipColors(),
                 label = { Text(stringResource(R.string.confirmation_dialog_label)) },
                 secondaryLabel = { Text(confirmationStatus) },
                 modifier = Modifier.fillMaxWidth()
             )
         }
         item {
-            Chip(
+            OutlinedChip(
                 onClick = {
                     alertStatus = ""
                     alertShowDialog = true
                 },
-                colors = ChipDefaults.primaryChipColors(),
                 label = { Text(stringResource(R.string.alert_dialog_label)) },
                 secondaryLabel = { Text(alertStatus) },
                 modifier = Modifier.fillMaxWidth()

--- a/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/ui/progressindicator/ProgressIndicators.kt
+++ b/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/ui/progressindicator/ProgressIndicators.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.shape.CutCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -59,6 +60,7 @@ fun ProgressIndicatorsScreen(
             item {
                 CompactChip(
                     onClick = menuItem.clickHander,
+                    shape = CutCornerShape(4.dp),
                     label = {
                         Text(
                             menuItem.name,


### PR DESCRIPTION
Demos for a new features available in Compose for Wear OS version 1.1:
- Using Outlined style for Chips at `Dialogs` screen
- Example of modifying Chip shape at `Progress Indicators` screen

![chip_styles_shape_demo](https://user-images.githubusercontent.com/1803903/206014353-fc93eec3-fd2f-4a16-8189-9ddbc05292f4.gif)