### PR TITLE
[AlwaysOnKotlin] Migrate to December version of Compose BoM for AlwaysOnKotlin

### DIFF
--- a/AlwaysOnKotlin/compose/build.gradle
+++ b/AlwaysOnKotlin/compose/build.gradle
@@ -72,6 +72,9 @@ android {
 }
 
 dependencies {
+    def composeBom = platform(libs.androidx.compose.bom)
+
+    implementation composeBom
     implementation libs.kotlinx.coroutines.android
     implementation libs.androidx.activity.compose
     implementation libs.compose.ui
@@ -84,6 +87,7 @@ dependencies {
     implementation libs.androidx.window
     implementation libs.compose.ui.test.manifest
 
+    androidTestImplementation composeBom
     androidTestImplementation libs.kotlinx.coroutines.test
     androidTestImplementation libs.test.core.ktx
     androidTestImplementation libs.test.ext.junit.ktx

--- a/AlwaysOnKotlin/gradle/libs.versions.toml
+++ b/AlwaysOnKotlin/gradle/libs.versions.toml
@@ -1,10 +1,10 @@
 [versions]
 android-gradle-plugin = "7.3.1"
 androidx-activity = "1.6.1"
+androidx-compose-bom = "2022.12.00"
 androidx-lifecycle = "2.5.1"
 androidx-test = "1.5.0"
 androidx-wear-compose = "1.1.0"
-compose = "1.3.1"
 compose-compiler = "1.3.2"
 ktlint = "0.46.1"
 org-jetbrains-kotlin = "1.7.20"
@@ -14,16 +14,17 @@ org-jetbrains-kotlinx = "1.6.4"
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
 androidx-activity-ktx = { module = "androidx.activity:activity-ktx", version.ref = "androidx-activity" }
 androidx-core-ktx = "androidx.core:core-ktx:1.9.0"
+androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "androidx-compose-bom" }
 androidx-databinding-viewbinding = "androidx.databinding:viewbinding:7.3.1"
 androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "androidx-lifecycle" }
 androidx-wear = "androidx.wear:wear:1.2.0"
 androidx-window = "androidx.window:window:1.0.0"
 com-google-truth = "com.google.truth:truth:1.1.3"
 compose-compiler = { module = "androidx.compose.compiler:compiler", version.ref = "compose-compiler" }
-compose-ui = { module = "androidx.compose.ui:ui", version.ref = "compose" }
-compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "compose" }
-compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "compose" }
-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose" }
+compose-ui = { module = "androidx.compose.ui:ui" }
+compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4" }
+compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest" }
+compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
 jacoco-ant = "org.jacoco:org.jacoco.ant:0.8.8"
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "org-jetbrains-kotlin" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "org-jetbrains-kotlinx" }


### PR DESCRIPTION
Thanks for a very cool sample repo! I really like it! :) 

Starting to use the Compose BoM for the AlwaysOnKotlin project. My plan is to add a PR for each project in this repo to migrate to use the Compose BoM.

I was not 100% sure if it is the best approach to separate it into one PR for each project vs one PR for everything. However, I felt that it might be a bit easier to review it then. 

Issue is relating to #584  although it is the December version not October now.