### PR TITLE
[ComposeStarter] Use December BoM for Compose dependencies

### DIFF
--- a/ComposeStarter/app/build.gradle
+++ b/ComposeStarter/app/build.gradle
@@ -59,7 +59,11 @@ android {
 }
 
 dependencies {
+
+    def composeBom = platform(libs.androidx.compose.bom)
+
     // General compose dependencies
+    implementation composeBom
     implementation libs.androidx.activity.compose
     implementation libs.compose.ui.tooling.preview
 
@@ -80,8 +84,12 @@ dependencies {
 
     // Testing
     testImplementation libs.junit
+
     androidTestImplementation libs.test.ext.junit
     androidTestImplementation libs.test.espresso.core
     androidTestImplementation libs.compose.ui.test.junit4
+    androidTestImplementation composeBom
+
     debugImplementation libs.compose.ui.tooling
+    debugImplementation composeBom
 }

--- a/ComposeStarter/gradle/libs.versions.toml
+++ b/ComposeStarter/gradle/libs.versions.toml
@@ -1,12 +1,12 @@
 [versions]
 android-gradle-plugin = "7.3.1"
 androidx-activity = "1.6.1"
+androidx-compose-bom = "2022.12.00"
 androidx-lifecycle = "2.4.1"
 androidx-test = "1.4.0"
 androidx-wear-compose = "1.1.0"
 androidx-wear-tiles = "1.0.1"
 androidx-wear-watchface = "1.0.1"
-compose = "1.3.1"
 compose-compiler = "1.3.2"
 ktlint = "0.46.1"
 org-jetbrains-kotlin = "1.7.20"
@@ -15,10 +15,11 @@ org-jetbrains-kotlinx = "1.6.0"
 [libraries]
 android-lint-gradle = "com.android.tools.lint:lint-gradle:30.3.1"
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
+androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "androidx-compose-bom" }
 compose-compiler = { module = "androidx.compose.compiler:compiler", version.ref = "compose-compiler" }
-compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "compose" }
-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose" }
-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "compose" }
+compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4" }
+compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
+compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
 jacoco-ant = "org.jacoco:org.jacoco.ant:0.8.8"
 junit = "junit:junit:4.13.2"
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "org-jetbrains-kotlin" }


### PR DESCRIPTION
Start using the December BoM for the Compose dependencies in the Compose Starter project.

Following up #631 relating to #584 