### PR TITLE
[ComposeAdvanced] Start using the December BoM for Compose dependencies

### DIFF
--- a/ComposeAdvanced/app/build.gradle
+++ b/ComposeAdvanced/app/build.gradle
@@ -85,7 +85,10 @@ android {
 }
 
 dependencies {
+    def composeBom = platform(libs.androidx.compose.bom)
+
     // General compose dependencies
+    implementation composeBom
     implementation libs.androidx.activity.compose
     implementation libs.compose.ui.tooling.preview
     implementation libs.compose.foundation
@@ -135,6 +138,7 @@ dependencies {
 
     // Testing
     testImplementation libs.junit
+    androidTestImplementation composeBom
     androidTestImplementation libs.test.ext.junit
     androidTestImplementation libs.test.espresso.core
     androidTestImplementation libs.compose.ui.test.junit4

--- a/ComposeAdvanced/gradle/libs.versions.toml
+++ b/ComposeAdvanced/gradle/libs.versions.toml
@@ -2,12 +2,12 @@
 android-gradle-plugin = "7.3.1"
 androidx-activity = "1.6.1"
 androidx-benchmark = "1.1.1"
+androidx-compose-bom = "2022.12.00"
 androidx-lifecycle = "2.5.1"
 androidx-test-espresso = "3.5.0"
 androidx-test-ext = "1.1.4"
 androidx-test-uiautomator = "2.2.0"
 androidx-wear-compose = "1.1.0"
-compose = "1.3.1"
 compose-compiler = "1.3.2"
 horologist = "0.2.5"
 ktlint = "0.46.1"
@@ -18,6 +18,7 @@ org-jetbrains-kotlin = "1.7.20"
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
 androidx-benchmark-junit4 = { module = "androidx.benchmark:benchmark-junit4", version.ref = "androidx-benchmark" }
 androidx-benchmark-macro-junit4 = { module = "androidx.benchmark:benchmark-macro-junit4", version.ref = "androidx-benchmark" }
+androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "androidx-compose-bom" }
 androidx-lifecycle-common-java8 = { module = "androidx.lifecycle:lifecycle-common-java8", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-viewmodel-ktx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "androidx-lifecycle" }
@@ -32,13 +33,13 @@ androidx-tracing-ktx = "androidx.tracing:tracing-ktx:1.1.0"
 com-google-maps-compose = "com.google.maps.android:maps-compose:2.8.0"
 com-google-play-services-maps = "com.google.android.gms:play-services-maps:18.1.0"
 compose-compiler = { module = "androidx.compose.compiler:compiler", version.ref = "compose-compiler" }
-compose-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "compose" }
-compose-material-iconscore = { module = "androidx.compose.material:material-icons-core", version.ref = "compose" }
-compose-material-iconsext = { module = "androidx.compose.material:material-icons-extended", version.ref = "compose" }
-compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "compose" }
-compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "compose" }
-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose" }
-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "compose" }
+compose-foundation = { module = "androidx.compose.foundation:foundation" }
+compose-material-iconscore = { module = "androidx.compose.material:material-icons-core" }
+compose-material-iconsext = { module = "androidx.compose.material:material-icons-extended" }
+compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4" }
+compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest" }
+compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
+compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
 horologist-composables = { module = "com.google.android.horologist:horologist-composables", version.ref = "horologist" }
 horologist-compose-layout = { module = "com.google.android.horologist:horologist-compose-layout", version.ref = "horologist" }
 jacoco-ant = "org.jacoco:org.jacoco.ant:0.8.8"


### PR DESCRIPTION
Start using the December BoM for Compose dependencies in the ComposeAdvanced sample.

Following up #631 relating to #584 