### PR TITLE
[DataLayer] Start using the December Compose BoM for Compose dependencies

### DIFF
--- a/DataLayer/Application/build.gradle
+++ b/DataLayer/Application/build.gradle
@@ -58,8 +58,11 @@ android {
 }
 
 dependencies {
+    def composeBom = platform(libs.androidx.compose.bom)
+
     coreLibraryDesugaring libs.android.desugarjdklibs
 
+    implementation composeBom
     implementation libs.kotlinx.coroutines.core
     implementation libs.kotlinx.coroutines.android
     implementation libs.kotlinx.coroutines.play.services

--- a/DataLayer/Wearable/build.gradle
+++ b/DataLayer/Wearable/build.gradle
@@ -65,6 +65,9 @@ android {
 }
 
 dependencies {
+    def composeBom = platform(libs.androidx.compose.bom)
+
+    implementation composeBom
     implementation libs.kotlinx.coroutines.core
     implementation libs.kotlinx.coroutines.android
     implementation libs.kotlinx.coroutines.play.services

--- a/DataLayer/gradle/libs.versions.toml
+++ b/DataLayer/gradle/libs.versions.toml
@@ -1,9 +1,9 @@
 [versions]
 android-gradle-plugin = "7.3.1"
 androidx-activity = "1.6.1"
+androidx-compose-bom = "2022.12.00"
 androidx-lifecycle = "2.5.1"
 androidx-wear-compose = "1.1.0"
-compose = "1.3.1"
 compose-compiler = "1.3.2"
 ktlint = "0.46.1"
 org-jetbrains-kotlin = "1.7.20"
@@ -12,15 +12,16 @@ org-jetbrains-kotlinx = "1.6.4"
 [libraries]
 android-desugarjdklibs = "com.android.tools:desugar_jdk_libs:1.2.2"
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
+androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "androidx-compose-bom" }
 androidx-core-ktx = "androidx.core:core-ktx:1.9.0"
 androidx-fragment-ktx = "androidx.fragment:fragment-ktx:1.5.5"
 androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-viewmodel-ktx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "androidx-lifecycle" }
 compose-compiler = { module = "androidx.compose.compiler:compiler", version.ref = "compose-compiler" }
-compose-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "compose" }
-compose-material = { module = "androidx.compose.material:material", version.ref = "compose" }
-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose" }
+compose-foundation = { module = "androidx.compose.foundation:foundation" }
+compose-material = { module = "androidx.compose.material:material" }
+compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
 jacoco-ant = "org.jacoco:org.jacoco.ant:0.8.8"
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "org-jetbrains-kotlin" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "org-jetbrains-kotlinx" }


### PR DESCRIPTION
Migrate to the December version of the BoM for Compose dependencies in the DataLayer project.

Following up #631 relating to #584 