### PR TITLE
[WearSpeakerSample] Start using the December BoM for Compose dependencies

### DIFF
--- a/WearSpeakerSample/gradle/libs.versions.toml
+++ b/WearSpeakerSample/gradle/libs.versions.toml
@@ -1,9 +1,9 @@
 [versions]
 android-gradle-plugin = "7.3.1"
 androidx-activity = "1.6.1"
+androidx-compose-bom = "2022.12.00"
 androidx-lifecycle = "2.5.1"
 androidx-wear-compose = "1.1.0"
-compose = "1.3.1"
 compose-compiler = "1.3.2"
 ktlint = "0.46.1"
 org-jetbrains-kotlin = "1.7.20"
@@ -11,12 +11,13 @@ org-jetbrains-kotlinx = "1.6.4"
 
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
+androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "androidx-compose-bom" }
 androidx-constraintlayout-compose = "androidx.constraintlayout:constraintlayout-compose:1.0.1"
 androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "androidx-lifecycle" }
 androidx-media = "androidx.media:media:1.6.0"
-compose-material-icons-extended = { module = "androidx.compose.material:material-icons-extended", version.ref = "compose" }
-compose-material-ripple = { module = "androidx.compose.material:material-ripple", version.ref = "compose" }
-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose" }
+compose-material-icons-extended = { module = "androidx.compose.material:material-icons-extended" }
+compose-material-ripple = { module = "androidx.compose.material:material-ripple" }
+compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
 jacoco-ant = "org.jacoco:org.jacoco.ant:0.8.8"
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "org-jetbrains-kotlin" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "org-jetbrains-kotlinx" }

--- a/WearSpeakerSample/wear/build.gradle
+++ b/WearSpeakerSample/wear/build.gradle
@@ -57,6 +57,9 @@ android {
 }
 
 dependencies {
+    def composeBom = platform(libs.androidx.compose.bom)
+
+    implementation composeBom
     implementation libs.kotlinx.coroutines.android
     implementation libs.androidx.activity.compose
     implementation libs.compose.material.ripple


### PR DESCRIPTION
Start using the December BoM for Compose dependencies on the WearSpeakerSample project.

Following up #631 relating to #584 