### PR TITLE
[WearStandaloneGoogleSignIn] Start using the December BoM for Compose  dependencies

### DIFF
--- a/WearStandaloneGoogleSignIn/app/build.gradle
+++ b/WearStandaloneGoogleSignIn/app/build.gradle
@@ -65,6 +65,10 @@ android {
 }
 
 dependencies {
+
+    def composeBom = platform(libs.androidx.compose.bom)
+
+    implementation composeBom
     implementation libs.kotlinx.coroutines.core
     implementation libs.kotlinx.coroutines.android
     implementation libs.kotlinx.coroutines.play.services

--- a/WearStandaloneGoogleSignIn/gradle/libs.versions.toml
+++ b/WearStandaloneGoogleSignIn/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
 android-gradle-plugin = "7.3.1"
 androidx-activity = "1.6.1"
+androidx-compose-bom = "2022.12.00"
 androidx-wear-compose = "1.1.0"
-compose = "1.3.1"
 compose-compiler = "1.3.2"
 ktlint = "0.46.1"
 org-jetbrains-kotlin = "1.7.20"
@@ -10,9 +10,10 @@ org-jetbrains-kotlinx = "1.6.4"
 
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
+androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "androidx-compose-bom" }
 compose-compiler = { module = "androidx.compose.compiler:compiler", version.ref = "compose-compiler" }
-compose-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "compose" }
-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose" }
+compose-foundation = { module = "androidx.compose.foundation:foundation" }
+compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
 jacoco-ant = "org.jacoco:org.jacoco.ant:0.8.8"
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "org-jetbrains-kotlin" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "org-jetbrains-kotlinx" }


### PR DESCRIPTION
Start using the December BoM for Compose dependencies in the WearStandaloneGoogleSignIn project. 

Following up #631 relating to #584 

According to the Readme, this should be the last project in this repo that uses compose so, if this PR gets merged the last, this should resolve #584 :) 