### PR TITLE
[RuntimePermissionsWear] Remove dependency with wearApp configuration

### DIFF
--- a/RuntimePermissionsWear/Application/build.gradle
+++ b/RuntimePermissionsWear/Application/build.gradle
@@ -61,5 +61,4 @@ dependencies {
     implementation libs.playservices.wearable
 
     implementation projects.shared
-    wearApp projects.wearable
 }


### PR DESCRIPTION
#### WHAT

Remove from the mobile app module of the `RuntimePermissionsWear` sample, the dependency on the wear app module with `wearApp` configuration.

#### WHY

It does seem to be needed. I did **not** test the app after the changes, but the other apps were still working fine after it was removed in https://github.com/android/wear-os-samples/pull/586 and https://github.com/android/wear-os-samples/pull/589. Also, the only place in the [documentation](https://developer.android.com/studio/build/dependencies#wear_apps) that I could find reference to this configuration was updated this morning, removing the reference.

Fixes #585 