### PR TITLE
[AlwaysOnKotlin] add missing dependency for release

### DIFF
--- a/AlwaysOnKotlin/compose/build.gradle
+++ b/AlwaysOnKotlin/compose/build.gradle
@@ -86,6 +86,9 @@ dependencies {
     implementation libs.wear.compose.material
     implementation libs.androidx.window
     implementation libs.compose.ui.test.manifest
+    
+    // Release mode doesn't work without that dependency
+    compileOnly "com.google.android.wearable:wearable:2.9.0"
 
     androidTestImplementation composeBom
     androidTestImplementation libs.kotlinx.coroutines.test


### PR DESCRIPTION
If `com.google.android.wearable:wearable:2.9.0` isn't specified then the ambient mode won't be triggered in release mode