### PR TITLE
[ComposeAdvanced] Fix ToggleChip in RTL

### DIFF
--- a/ComposeAdvanced/app/build.gradle
+++ b/ComposeAdvanced/app/build.gradle
@@ -71,6 +71,7 @@ android {
         // Allow for widescale experimental APIs in Alpha libraries we build upon
         freeCompilerArgs += "-opt-in=androidx.wear.compose.material.ExperimentalWearMaterialApi"
         freeCompilerArgs += "-opt-in=androidx.compose.animation.ExperimentalAnimationApi"
+        freeCompilerArgs += "-opt-in=com.google.android.horologist.annotations.ExperimentalHorologistApi"
     }
 
     buildFeatures {
@@ -135,6 +136,7 @@ dependencies {
     // Horologist
     implementation libs.horologist.composables
     implementation libs.horologist.compose.layout
+    implementation libs.horologist.compose.material
     implementation libs.wear.input
 
     implementation libs.androidx.splashscreen

--- a/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/ui/landing/LandingScreen.kt
+++ b/ComposeAdvanced/app/src/main/java/com/example/android/wearable/composeadvanced/presentation/ui/landing/LandingScreen.kt
@@ -30,8 +30,6 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -50,11 +48,12 @@ import androidx.wear.compose.material.Chip
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Switch
 import androidx.wear.compose.material.Text
-import androidx.wear.compose.material.ToggleChip
 import androidx.wear.compose.material.curvedText
 import com.example.android.wearable.composeadvanced.R
 import com.example.android.wearable.composeadvanced.presentation.MenuItem
 import com.example.android.wearable.composeadvanced.presentation.ui.util.ReportFullyDrawn
+import com.google.android.horologist.compose.material.ToggleChip
+import com.google.android.horologist.compose.material.ToggleChipToggleControl
 import com.google.android.horologist.compose.navscaffold.scrollableColumn
 
 /**
@@ -117,23 +116,9 @@ fun LandingScreen(
                 ToggleChip(
                     modifier = Modifier.fillMaxWidth(),
                     checked = proceedingTimeTextEnabled,
-                    onCheckedChange = onClickProceedingTimeText,
-                    label = {
-                        Text(
-                            text = stringResource(R.string.proceeding_text_toggle_chip_label),
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis
-                        )
-                    },
-                    toggleControl = {
-                        Switch(
-                            checked = proceedingTimeTextEnabled,
-                            modifier = Modifier.semantics {
-                                this.contentDescription =
-                                    if (proceedingTimeTextEnabled) "On" else "Off"
-                            }
-                        )
-                    }
+                    onCheckedChanged = onClickProceedingTimeText,
+                    label = stringResource(R.string.proceeding_text_toggle_chip_label),
+                    toggleControl = ToggleChipToggleControl.Switch
                 )
             }
         }

--- a/ComposeAdvanced/gradle/libs.versions.toml
+++ b/ComposeAdvanced/gradle/libs.versions.toml
@@ -46,6 +46,7 @@ compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview"
 
 horologist-composables = { module = "com.google.android.horologist:horologist-composables", version.ref = "horologist" }
 horologist-compose-layout = { module = "com.google.android.horologist:horologist-compose-layout", version.ref = "horologist" }
+horologist-compose-material = { module = "com.google.android.horologist:horologist-compose-material", version.ref = "horologist" }
 jacoco-ant = "org.jacoco:org.jacoco.ant:0.8.10"
 junit = "junit:junit:4.13.2"
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "org-jetbrains-kotlin" }


### PR DESCRIPTION
#### WHAT

Fix display of switch controls in `ToggleChip` in RTL in ComposeAdvanced sample.

| Before | After |
|--------|--------|
|![ToggleChip_RTL_before](https://github.com/android/wear-os-samples/assets/878134/c7242cef-1fe6-4351-aac0-0aad82982e68) |![ToggleChip_RTL_after](https://github.com/android/wear-os-samples/assets/878134/6e4f5712-3fda-414c-a934-4356450948a4) | 

#### WHY

The switch control is displaying on the wrong direction in RTL.

#### HOW

Use `ToggleChip` from Horologist [Compose Material](https://github.com/google/horologist/tree/main/compose-material).



