### PR TITLE
Updates use of Template to use Parameter to ensure valid WFF

### DIFF
--- a/WatchFaceFormat/SimpleDigital/res/raw/watchface.xml
+++ b/WatchFaceFormat/SimpleDigital/res/raw/watchface.xml
@@ -49,7 +49,7 @@
         <Text align="CENTER">
           <!-- Demonstrates using Android string resources for localization -->
           <Font family="SYNC_TO_DEVICE" size="36" color="#ffffffff">
-            <Template>@string/greeting</Template>
+            <Template>%s<Parameter expression="greeting"></Parameter></Template>
           </Font>
         </Text>
       </PartText>


### PR DESCRIPTION
`Template` must have at least 1 `Parameter` element, even though the renderer may work without.

Resources should be specified without the `@string` prefix.