### PR TITLE
focus on scroll view when creating watch config activity

### DIFF
--- a/WatchFaceKotlin/app/src/main/java/com/example/android/wearable/alpha/editor/WatchFaceConfigActivity.kt
+++ b/WatchFaceKotlin/app/src/main/java/com/example/android/wearable/alpha/editor/WatchFaceConfigActivity.kt
@@ -51,6 +51,9 @@ class WatchFaceConfigActivity : ComponentActivity() {
 
         binding = ActivityWatchFaceConfigBinding.inflate(layoutInflater)
         setContentView(binding.root)
+        // google wear os guidelines require scrollable options to accept rotary input
+        // lets focus scroll_view on watch face config activity creation
+        binding.scrollView.requestFocus()
 
         // Disable widgets until data loads and values are set.
         binding.colorStylePickerButton.isEnabled = false

--- a/WatchFaceKotlin/app/src/main/res/layout/activity_watch_face_config.xml
+++ b/WatchFaceKotlin/app/src/main/res/layout/activity_watch_face_config.xml
@@ -18,6 +18,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/scroll_view"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="@color/black"


### PR DESCRIPTION
focus on scroll view when creating watch config activity to easily support rotary input from crown