### PR TITLE
Remove lint version from gradle.properties

### DIFF
--- a/AlwaysOnKotlin/gradle.properties
+++ b/AlwaysOnKotlin/gradle.properties
@@ -2,8 +2,6 @@ org.gradle.jvmargs=-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF
 android.enableJetifier=true
 android.useAndroidX=true
 android.sdk.channel=3
-# https://buganizer.corp.google.com/issues/311218673
-android.experimental.lint.version=8.4.0-alpha04
 android.experimental.testOptions.managedDevices.customDevice=true
 android.experimental.testOptions.managedDevices.maxConcurrentDevices=1
 android.experimental.testOptions.managedDevices.setupTimeoutMinutes=180


### PR DESCRIPTION
It's no longer necessary now that AGP has been updated to 8.3.X, and it causes errors when updating AGP to 8.4.0-alpha05 or higher.

See https://issuetracker.google.com/issues/331681802