### PR TITLE
Support breakpoints

### DIFF
--- a/WearTilesKotlin/app/src/main/java/com/example/wear/tiles/messaging/MessagingTileLayout.kt
+++ b/WearTilesKotlin/app/src/main/java/com/example/wear/tiles/messaging/MessagingTileLayout.kt
@@ -49,9 +49,10 @@ internal fun messagingTileLayout(
     .setContent(
         MultiButtonLayout.Builder()
             .apply {
-                // In a PrimaryLayout with a compact chip at the bottom, we can fit 5 buttons.
-                // We're only taking the first 4 contacts so that we can fit a Search button too.
-                state.contacts.take(4).forEach { contact ->
+                // A PrimaryLayout with a compact chip can fit 5 buttons (including search)
+                // on "small" displays, 6 on "large" displays.
+                val isLarge = deviceParameters.screenHeightDp >= 225
+                state.contacts.take(if (isLarge) 5 else 4).forEach { contact ->
                     addButtonContent(contactLayout(context, contact, emptyClickable))
                 }
             }


### PR DESCRIPTION
Before:

<img width="268" alt="Screenshot 2024-08-02 at 12 37 21" src="https://github.com/user-attachments/assets/449eff01-5884-4896-afa5-1a1b326673c3">

After:

<img width="269" alt="Screenshot 2024-08-02 at 12 37 02" src="https://github.com/user-attachments/assets/dd6c23de-e0ac-45ba-80c7-d0473a5c23ab">
