### PR TITLE
Support drawables "directly"

### DIFF
--- a/WearTilesKotlin/app/src/main/java/com/example/wear/tiles/messaging/MessagingTileLayout.kt
+++ b/WearTilesKotlin/app/src/main/java/com/example/wear/tiles/messaging/MessagingTileLayout.kt
@@ -16,8 +16,10 @@
 package com.example.wear.tiles.messaging
 
 import android.content.Context
+import androidx.annotation.DrawableRes
 import androidx.wear.protolayout.DeviceParametersBuilders
 import androidx.wear.protolayout.ModifiersBuilders
+import androidx.wear.protolayout.ResourceBuilders
 import androidx.wear.protolayout.ResourceBuilders.Resources
 import androidx.wear.protolayout.material.Button
 import androidx.wear.protolayout.material.ButtonColors
@@ -32,7 +34,6 @@ import androidx.wear.tooling.preview.devices.WearDevices
 import com.example.wear.tiles.R
 import com.example.wear.tiles.golden.resources
 import com.example.wear.tiles.tools.emptyClickable
-import com.google.android.horologist.tiles.images.drawableResToImageResource
 
 /**
  * Layout definition for the Messaging Tile.
@@ -57,7 +58,8 @@ internal fun messagingTileLayout(
             }
             .addButtonContent(searchLayout(context, emptyClickable))
             .build()
-    ).setPrimaryChipContent(
+    )
+    .setPrimaryChipContent(
         CompactChip.Builder(
             context,
             context.getString(R.string.tile_messaging_create_new),
@@ -104,15 +106,15 @@ private fun messagingTilePreview(context: Context): TilePreviewData {
         onTileResourceRequest = resources {
             addIdToImageMapping(
                 state.contacts[1].imageResourceId(),
-                drawableResToImageResource(R.drawable.ali)
+                R.drawable.ali
             )
             addIdToImageMapping(
                 state.contacts[2].imageResourceId(),
-                drawableResToImageResource(R.drawable.taylor)
+                R.drawable.taylor
             )
             addIdToImageMapping(
                 MessagingTileRenderer.ID_IC_SEARCH,
-                drawableResToImageResource(R.drawable.ic_search_24)
+                R.drawable.ic_search_24
             )
         },
         onTileRequest = { request ->
@@ -147,7 +149,7 @@ private fun contactWithImagePreview(context: Context): TilePreviewData {
         onTileResourceRequest = {
             Resources.Builder().addIdToImageMapping(
                 "${MessagingTileRenderer.ID_CONTACT_PREFIX}${contact.id}",
-                drawableResToImageResource(R.drawable.ali)
+                R.drawable.ali
             ).build()
         },
         onTileRequest = {
@@ -162,7 +164,7 @@ private fun searchButtonPreview(context: Context) = TilePreviewData(
     onTileResourceRequest = {
         Resources.Builder().addIdToImageMapping(
             MessagingTileRenderer.ID_IC_SEARCH,
-            drawableResToImageResource(R.drawable.ic_search_24)
+            R.drawable.ic_search_24
         ).build()
     },
     onTileRequest = {
@@ -170,3 +172,16 @@ private fun searchButtonPreview(context: Context) = TilePreviewData(
             searchLayout(context, emptyClickable)
         ).build()
     })
+
+fun Resources.Builder.addIdToImageMapping(
+    id: String,
+    @DrawableRes resId: Int
+): Resources.Builder = addIdToImageMapping(
+    id, ResourceBuilders.ImageResource.Builder()
+        .setAndroidResourceByResId(
+            ResourceBuilders.AndroidImageResourceByResId.Builder()
+                .setResourceId(resId)
+                .build()
+        )
+        .build()
+)

--- a/WearTilesKotlin/app/src/main/java/com/example/wear/tiles/messaging/MessagingTileRenderer.kt
+++ b/WearTilesKotlin/app/src/main/java/com/example/wear/tiles/messaging/MessagingTileRenderer.kt
@@ -50,7 +50,7 @@ class MessagingTileRenderer(context: Context) :
                 /* id = */
                 ID_IC_SEARCH,
                 /* image = */
-                drawableResToImageResource(R.drawable.ic_search_24)
+                R.drawable.ic_search_24
             )
         }
 


### PR DESCRIPTION
1. Is this the right API? (c.f. Horologist's [drawableResToImageResource()](https://github.com/google/horologist/blob/27802d54d07ca17061b6a13185c77586bc6c5f02/tiles/src/main/java/com/google/android/horologist/tiles/images/DrawableResToImageResource.kt#L28) approach.)
2. Is this the right place to put it? (Should it be in `tools/`?)
3. What happens if Tiles just adds this in a future release (as a regular method)? This code will error at compile time but … that's probably okay?