### PR TITLE
apply responsive tiles to alarm, calendar, news, timer, mediation

### DIFF
--- a/WearTilesKotlin/app/src/debug/java/com/example/wear/tiles/golden/Alarm.kt
+++ b/WearTilesKotlin/app/src/debug/java/com/example/wear/tiles/golden/Alarm.kt
@@ -25,6 +25,11 @@ import androidx.wear.protolayout.material.Text
 import androidx.wear.protolayout.material.TitleChip
 import androidx.wear.protolayout.material.Typography
 import androidx.wear.protolayout.material.layouts.PrimaryLayout
+import androidx.wear.tiles.tooling.preview.Preview
+import androidx.wear.tiles.tooling.preview.TilePreviewData
+import androidx.wear.tiles.tooling.preview.TilePreviewHelper
+import androidx.wear.tooling.preview.devices.WearDevices
+import com.example.wear.tiles.tools.emptyClickable
 
 object Alarm {
 
@@ -36,6 +41,7 @@ object Alarm {
         alarmDays: String,
         clickable: Clickable
     ) = PrimaryLayout.Builder(deviceParameters)
+        .setResponsiveContentInsetEnabled(true)
         .setPrimaryLabelTextContent(
             Text.Builder(context, timeUntilAlarm)
                 .setColor(ColorBuilders.argb(GoldenTilesColors.White))
@@ -62,7 +68,25 @@ object Alarm {
             Text.Builder(context, alarmDays)
                 .setColor(ColorBuilders.argb(GoldenTilesColors.Yellow))
                 .setTypography(Typography.TYPOGRAPHY_CAPTION1)
+                .setMaxLines(2)
                 .build()
         )
         .build()
+}
+
+@Preview(device = WearDevices.SMALL_ROUND)
+@Preview(device = WearDevices.SMALL_ROUND, fontScale = 1.24f)
+@Preview(device = WearDevices.LARGE_ROUND)
+@Preview(device = WearDevices.LARGE_ROUND, fontScale = 1.24f)
+fun AlarmPreview(context: Context) = TilePreviewData {
+    TilePreviewHelper.singleTimelineEntryTileBuilder(
+        Alarm.layout(
+            context,
+            it.deviceConfiguration,
+            timeUntilAlarm = "Less than 1 min",
+            alarmTime = "14:58",
+            alarmDays = "Mon, Tue, Wed, Thu, Fri,Sat",
+            clickable = emptyClickable
+        )
+    ).build()
 }

--- a/WearTilesKotlin/app/src/debug/java/com/example/wear/tiles/golden/Calendar.kt
+++ b/WearTilesKotlin/app/src/debug/java/com/example/wear/tiles/golden/Calendar.kt
@@ -23,6 +23,11 @@ import androidx.wear.protolayout.material.CompactChip
 import androidx.wear.protolayout.material.Text
 import androidx.wear.protolayout.material.Typography
 import androidx.wear.protolayout.material.layouts.PrimaryLayout
+import androidx.wear.tiles.tooling.preview.Preview
+import androidx.wear.tiles.tooling.preview.TilePreviewData
+import androidx.wear.tiles.tooling.preview.TilePreviewHelper
+import androidx.wear.tooling.preview.devices.WearDevices
+import com.example.wear.tiles.tools.emptyClickable
 
 object Calendar {
 
@@ -34,6 +39,7 @@ object Calendar {
         eventLocation: String,
         clickable: Clickable
     ) = PrimaryLayout.Builder(deviceParameters)
+        .setResponsiveContentInsetEnabled(true)
         .setPrimaryLabelTextContent(
             Text.Builder(context, eventTime)
                 .setColor(ColorBuilders.argb(GoldenTilesColors.LightBlue))
@@ -57,4 +63,21 @@ object Calendar {
             CompactChip.Builder(context, "Agenda", clickable, deviceParameters).build()
         )
         .build()
+}
+
+@Preview(device = WearDevices.SMALL_ROUND)
+@Preview(device = WearDevices.SMALL_ROUND, fontScale = 1.24f)
+@Preview(device = WearDevices.LARGE_ROUND)
+@Preview(device = WearDevices.LARGE_ROUND, fontScale = 1.24f)
+fun CalendarPreview(context: Context) = TilePreviewData {
+    TilePreviewHelper.singleTimelineEntryTileBuilder(
+        Calendar.layout(
+            context,
+            it.deviceConfiguration,
+            eventTime = "6:30-7:30 PM",
+            eventName = "Morning Pilates with Christina Lloyd",
+            eventLocation = "216 Market Street",
+            clickable = emptyClickable
+        )
+    ).build()
 }

--- a/WearTilesKotlin/app/src/debug/java/com/example/wear/tiles/golden/GoldenTilesPreviewsRow2.kt
+++ b/WearTilesKotlin/app/src/debug/java/com/example/wear/tiles/golden/GoldenTilesPreviewsRow2.kt
@@ -61,6 +61,7 @@ fun MeditationChips(context: Context) = TilePreviewData(resources {
         Meditation.chipsLayout(
             context,
             it.deviceConfiguration,
+            numOfLeftTasks = 2,
             session1 = Meditation.Session(
                 label = "Breathe",
                 iconId = Meditation.CHIP_1_ICON_ID,
@@ -103,6 +104,7 @@ fun Timer(context: Context) = TilePreviewData {
             timer3 = Timer.Timer(minutes = "15", clickable = emptyClickable),
             timer4 = Timer.Timer(minutes = "20", clickable = emptyClickable),
             timer5 = Timer.Timer(minutes = "30", clickable = emptyClickable),
+            timer6 = Timer.Timer(minutes = "45", clickable = emptyClickable),
             clickable = emptyClickable
         )
     ).build()
@@ -117,7 +119,7 @@ fun Alarm(context: Context) = TilePreviewData {
             it.deviceConfiguration,
             timeUntilAlarm = "Less than 1 min",
             alarmTime = "14:58",
-            alarmDays = "Mon, Tue, Wed",
+            alarmDays = "Mon, Tue, Wed, Thu, Fri,Sat",
             clickable = emptyClickable
         )
     ).build()

--- a/WearTilesKotlin/app/src/debug/java/com/example/wear/tiles/golden/GoldenTilesPreviewsRow3.kt
+++ b/WearTilesKotlin/app/src/debug/java/com/example/wear/tiles/golden/GoldenTilesPreviewsRow3.kt
@@ -23,6 +23,7 @@ import androidx.wear.tooling.preview.devices.WearDevices
 import com.example.wear.tiles.R
 import com.example.wear.tiles.tools.emptyClickable
 import com.google.android.horologist.tiles.images.drawableResToImageResource
+import java.time.LocalDate
 
 /**
  * b/238560022 misaligned because we can't add an offset, small preview is clipped
@@ -61,6 +62,7 @@ fun News(context: Context) = TilePreviewData {
             it.deviceConfiguration,
             headline = "Millions still without power as new storm moves across US",
             newsVendor = "The New York Times",
+            date = LocalDate.now().minusDays(1),
             clickable = emptyClickable
         )
     ).build()

--- a/WearTilesKotlin/app/src/debug/java/com/example/wear/tiles/golden/GoldenTilesPreviewsRow3.kt
+++ b/WearTilesKotlin/app/src/debug/java/com/example/wear/tiles/golden/GoldenTilesPreviewsRow3.kt
@@ -23,7 +23,10 @@ import androidx.wear.tooling.preview.devices.WearDevices
 import com.example.wear.tiles.R
 import com.example.wear.tiles.tools.emptyClickable
 import com.google.android.horologist.tiles.images.drawableResToImageResource
+import java.time.Clock
 import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneOffset
 
 /**
  * b/238560022 misaligned because we can't add an offset, small preview is clipped
@@ -56,13 +59,17 @@ fun Weather(context: Context) = TilePreviewData(resources {
 @Preview(device = WearDevices.SMALL_ROUND)
 @Preview(device = WearDevices.LARGE_ROUND)
 fun News(context: Context) = TilePreviewData {
+    val now = LocalDateTime.of(2024, 8, 1, 0, 0).toInstant(ZoneOffset.UTC)
+    val clock = Clock.fixed(now, Clock.systemUTC().zone)
+
     TilePreviewHelper.singleTimelineEntryTileBuilder(
         News.layout(
             context,
             it.deviceConfiguration,
             headline = "Millions still without power as new storm moves across US",
             newsVendor = "The New York Times",
-            date = LocalDate.now().minusDays(1),
+            date = LocalDate.now(clock).minusDays(1),
+            clock = clock,
             clickable = emptyClickable
         )
     ).build()

--- a/WearTilesKotlin/app/src/debug/java/com/example/wear/tiles/golden/Meditation.kt
+++ b/WearTilesKotlin/app/src/debug/java/com/example/wear/tiles/golden/Meditation.kt
@@ -32,6 +32,13 @@ import androidx.wear.protolayout.material.Text
 import androidx.wear.protolayout.material.Typography
 import androidx.wear.protolayout.material.layouts.MultiButtonLayout
 import androidx.wear.protolayout.material.layouts.PrimaryLayout
+import androidx.wear.tiles.tooling.preview.Preview
+import androidx.wear.tiles.tooling.preview.TilePreviewData
+import androidx.wear.tiles.tooling.preview.TilePreviewHelper
+import androidx.wear.tooling.preview.devices.WearDevices
+import com.example.wear.tiles.R
+import com.example.wear.tiles.tools.emptyClickable
+import com.google.android.horologist.tiles.images.drawableResToImageResource
 
 object Meditation {
     const val CHIP_1_ICON_ID = "meditation_1"
@@ -40,10 +47,22 @@ object Meditation {
     fun chipsLayout(
         context: Context,
         deviceParameters: DeviceParameters,
+        numOfLeftTasks: Int,
         session1: Session,
         session2: Session,
         browseClickable: Clickable
     ) = PrimaryLayout.Builder(deviceParameters)
+        .setResponsiveContentInsetEnabled(true)
+        .apply {
+            if (deviceParameters.screenWidthDp > 225) {
+                setPrimaryLabelTextContent(
+                    Text.Builder(context, "$numOfLeftTasks mindful tasks left")
+                        .setTypography(Typography.TYPOGRAPHY_BODY2)
+                        .setColor(ColorBuilders.argb(GoldenTilesColors.Pink))
+                        .build()
+                )
+            }
+        }
         .setContent(
             Column.Builder()
                 // See the comment on `setWidth` below in `sessionChip()` too. The default width for
@@ -146,4 +165,38 @@ object Meditation {
 
     data class Session(val label: String, val iconId: String, val clickable: Clickable)
     data class Timer(val minutes: Int, val clickable: Clickable)
+}
+
+@Preview(device = WearDevices.SMALL_ROUND)
+@Preview(device = WearDevices.SMALL_ROUND, fontScale = 1.24f)
+@Preview(device = WearDevices.LARGE_ROUND)
+@Preview(device = WearDevices.LARGE_ROUND, fontScale = 1.24f)
+fun MeditationChipsPreview(context: Context) = TilePreviewData(resources {
+    addIdToImageMapping(
+        Meditation.CHIP_1_ICON_ID,
+        drawableResToImageResource(R.drawable.ic_breathe_24)
+    )
+    addIdToImageMapping(
+        Meditation.CHIP_2_ICON_ID,
+        drawableResToImageResource(R.drawable.ic_mindfulness_24)
+    )
+}) {
+    TilePreviewHelper.singleTimelineEntryTileBuilder(
+        Meditation.chipsLayout(
+            context,
+            it.deviceConfiguration,
+            numOfLeftTasks = 2,
+            session1 = Meditation.Session(
+                label = "Breathe",
+                iconId = Meditation.CHIP_1_ICON_ID,
+                clickable = emptyClickable
+            ),
+            session2 = Meditation.Session(
+                label = "Daily mindfulness",
+                iconId = Meditation.CHIP_2_ICON_ID,
+                clickable = emptyClickable
+            ),
+            browseClickable = emptyClickable
+        )
+    ).build()
 }

--- a/WearTilesKotlin/app/src/debug/java/com/example/wear/tiles/golden/News.kt
+++ b/WearTilesKotlin/app/src/debug/java/com/example/wear/tiles/golden/News.kt
@@ -23,16 +23,35 @@ import androidx.wear.protolayout.material.CompactChip
 import androidx.wear.protolayout.material.Text
 import androidx.wear.protolayout.material.Typography
 import androidx.wear.protolayout.material.layouts.PrimaryLayout
+import androidx.wear.tiles.tooling.preview.Preview
+import androidx.wear.tiles.tooling.preview.TilePreviewData
+import androidx.wear.tiles.tooling.preview.TilePreviewHelper
+import androidx.wear.tooling.preview.devices.WearDevices
+import com.example.wear.tiles.tools.emptyClickable
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
 
 object News {
 
     fun layout(
         context: Context,
         deviceParameters: DeviceParameters,
+        date: LocalDate,
         headline: String,
         newsVendor: String,
         clickable: Clickable
     ) = PrimaryLayout.Builder(deviceParameters)
+        .setResponsiveContentInsetEnabled(true)
+        .apply {
+             if (deviceParameters.screenWidthDp > 225) {
+                setPrimaryLabelTextContent(
+                    Text.Builder(context, date.formatLocalDateTime())
+                        .setColor(ColorBuilders.argb(GoldenTilesColors.White))
+                        .setTypography(Typography.TYPOGRAPHY_CAPTION1)
+                        .build()
+                )
+            }        }
         .setContent(
             Text.Builder(context, headline)
                 .setMaxLines(3)
@@ -51,3 +70,31 @@ object News {
         )
         .build()
 }
+
+fun LocalDate.formatLocalDateTime(today: LocalDate = LocalDate.now()): String {
+    val yesterday = today.minusDays(1)
+
+    return when {
+        this == yesterday -> "yesterday ${format(DateTimeFormatter.ofPattern("MMM d"))}"
+        this == today -> "today ${format(DateTimeFormatter.ofPattern("MMM d"))}"
+        else -> format(DateTimeFormatter.ofLocalizedDate(FormatStyle.FULL))
+    }
+}
+
+@Preview(device = WearDevices.SMALL_ROUND)
+@Preview(device = WearDevices.SMALL_ROUND, fontScale = 1.24f)
+@Preview(device = WearDevices.LARGE_ROUND)
+@Preview(device = WearDevices.LARGE_ROUND, fontScale = 1.24f)
+fun NewsPreview(context: Context) = TilePreviewData {
+    TilePreviewHelper.singleTimelineEntryTileBuilder(
+        News.layout(
+            context,
+            it.deviceConfiguration,
+            headline = "Millions still without power as new storm moves across US",
+            newsVendor = "The New York Times",
+            date = LocalDate.now().minusDays(1),
+            clickable = emptyClickable
+        )
+    ).build()
+}
+

--- a/WearTilesKotlin/app/src/debug/java/com/example/wear/tiles/golden/News.kt
+++ b/WearTilesKotlin/app/src/debug/java/com/example/wear/tiles/golden/News.kt
@@ -28,7 +28,10 @@ import androidx.wear.tiles.tooling.preview.TilePreviewData
 import androidx.wear.tiles.tooling.preview.TilePreviewHelper
 import androidx.wear.tooling.preview.devices.WearDevices
 import com.example.wear.tiles.tools.emptyClickable
+import java.time.Clock
 import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 
@@ -38,6 +41,7 @@ object News {
         context: Context,
         deviceParameters: DeviceParameters,
         date: LocalDate,
+        clock: Clock = Clock.systemDefaultZone(),
         headline: String,
         newsVendor: String,
         clickable: Clickable
@@ -46,7 +50,7 @@ object News {
         .apply {
              if (deviceParameters.screenWidthDp > 225) {
                 setPrimaryLabelTextContent(
-                    Text.Builder(context, date.formatLocalDateTime())
+                    Text.Builder(context, date.formatLocalDateTime(today = LocalDate.now(clock)))
                         .setColor(ColorBuilders.argb(GoldenTilesColors.White))
                         .setTypography(Typography.TYPOGRAPHY_CAPTION1)
                         .build()
@@ -86,13 +90,17 @@ fun LocalDate.formatLocalDateTime(today: LocalDate = LocalDate.now()): String {
 @Preview(device = WearDevices.LARGE_ROUND)
 @Preview(device = WearDevices.LARGE_ROUND, fontScale = 1.24f)
 fun NewsPreview(context: Context) = TilePreviewData {
+    val now = LocalDateTime.of(2024, 8, 1, 0, 0).toInstant(ZoneOffset.UTC)
+    val clock = Clock.fixed(now, Clock.systemUTC().zone)
+
     TilePreviewHelper.singleTimelineEntryTileBuilder(
         News.layout(
             context,
             it.deviceConfiguration,
             headline = "Millions still without power as new storm moves across US",
             newsVendor = "The New York Times",
-            date = LocalDate.now().minusDays(1),
+            date = LocalDate.now(clock).minusDays(1),
+            clock = clock,
             clickable = emptyClickable
         )
     ).build()

--- a/WearTilesKotlin/app/src/debug/java/com/example/wear/tiles/golden/Timer.kt
+++ b/WearTilesKotlin/app/src/debug/java/com/example/wear/tiles/golden/Timer.kt
@@ -26,6 +26,11 @@ import androidx.wear.protolayout.material.CompactChip
 import androidx.wear.protolayout.material.Typography
 import androidx.wear.protolayout.material.layouts.MultiButtonLayout
 import androidx.wear.protolayout.material.layouts.PrimaryLayout
+import androidx.wear.tiles.tooling.preview.Preview
+import androidx.wear.tiles.tooling.preview.TilePreviewData
+import androidx.wear.tiles.tooling.preview.TilePreviewHelper
+import androidx.wear.tooling.preview.devices.WearDevices
+import com.example.wear.tiles.tools.emptyClickable
 
 object Timer {
 
@@ -37,8 +42,10 @@ object Timer {
         timer3: Timer,
         timer4: Timer,
         timer5: Timer,
+        timer6: Timer,
         clickable: Clickable
     ) = PrimaryLayout.Builder(deviceParameters)
+        .setResponsiveContentInsetEnabled(true)
         .setContent(
             MultiButtonLayout.Builder()
                 .addButtonContent(timerButton(context, timer1))
@@ -46,6 +53,11 @@ object Timer {
                 .addButtonContent(timerButton(context, timer3))
                 .addButtonContent(timerButton(context, timer4))
                 .addButtonContent(timerButton(context, timer5))
+                .apply {
+                    if (deviceParameters.screenWidthDp > 225) {
+                        addButtonContent(timerButton(context, timer6))
+                    }
+                }
                 .build()
         )
         .setPrimaryChipContent(
@@ -76,4 +88,24 @@ object Timer {
             .build()
 
     data class Timer(val minutes: String, val clickable: Clickable)
+}
+
+@Preview(device = WearDevices.SMALL_ROUND)
+@Preview(device = WearDevices.SMALL_ROUND, fontScale = 1.24f)
+@Preview(device = WearDevices.LARGE_ROUND)
+@Preview(device = WearDevices.LARGE_ROUND, fontScale = 1.24f)
+fun TimerPreview(context: Context) = TilePreviewData {
+    TilePreviewHelper.singleTimelineEntryTileBuilder(
+        Timer.layout(
+            context,
+            it.deviceConfiguration,
+            timer1 = Timer.Timer(minutes = "05", clickable = emptyClickable),
+            timer2 = Timer.Timer(minutes = "10", clickable = emptyClickable),
+            timer3 = Timer.Timer(minutes = "15", clickable = emptyClickable),
+            timer4 = Timer.Timer(minutes = "20", clickable = emptyClickable),
+            timer5 = Timer.Timer(minutes = "30", clickable = emptyClickable),
+            timer6 = Timer.Timer(minutes = "45", clickable = emptyClickable),
+            clickable = emptyClickable
+        )
+    ).build()
 }


### PR DESCRIPTION
I applied responsive tiles to alarm, calendar, news, timer, meditation.

<img width="738" alt="image" src="https://github.com/user-attachments/assets/9382f25c-7fef-4c80-9976-4e8cd6e175cd">

<img width="739" alt="image" src="https://github.com/user-attachments/assets/4e48f591-f171-49f7-a506-d58ec65324a1">

<img width="749" alt="image" src="https://github.com/user-attachments/assets/97b2a91a-998b-4ef6-acf2-e0c985350b6a">

<img width="738" alt="image" src="https://github.com/user-attachments/assets/bce2f6a6-f44e-406a-985d-4707b43e52d9">

<img width="733" alt="image" src="https://github.com/user-attachments/assets/98ae2d27-e561-43c2-9a2e-c7ae31d55cf2">
