### PR TITLE
Add wear_keep file to wear datalayer sample

### DIFF
--- a/DataLayer/Wearable/src/main/res/raw/wear_keep.xml
+++ b/DataLayer/Wearable/src/main/res/raw/wear_keep.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright 2024 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<resources xmlns:tools="http://schemas.android.com/tools" tools:keep="@array/android_wear_capabilities"/>


### PR DESCRIPTION
In reference to https://github.com/google/horologist/pull/2385#issuecomment-2349196318 adding the wear_keep file to the raw folder in the wear sample. From what I understand from https://issuetracker.google.com/issues/348688201#comment4 this is needed for the resource shrinker to work.