### PR TITLE
Adds support for Memory Footprint tool

### DIFF
--- a/WatchFaceFormat/validator-plugin/plugins/src/main/kotlin/AdbInstallTask.kt
+++ b/WatchFaceFormat/validator-plugin/plugins/src/main/kotlin/AdbInstallTask.kt
@@ -17,9 +17,10 @@
 import com.android.build.api.variant.BuiltArtifactsLoader
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
-import org.gradle.api.file.Directory
-import org.gradle.api.provider.Provider
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.options.Option
@@ -33,17 +34,19 @@ const val SET_WATCH_FACE_CMD =
 /**
  * Installs and sets watch face on an attached device via ADB.
  */
-open class AdbInstallTask @Inject constructor(@Internal val execOperations: ExecOperations) :
-    DefaultTask() {
+abstract class AdbInstallTask() : DefaultTask() {
+    @get:Inject
+    abstract val execOperations: ExecOperations
+
     @set:Option(option = "device", description = "The ADB device to install on")
     @get:Input
     var device: String = ""
 
-    @get:Input
-    lateinit var apkLocation: Provider<Directory>
+    @get:InputDirectory
+    abstract val apkLocation: DirectoryProperty
 
-    @get:Input
-    lateinit var artifactLoader: BuiltArtifactsLoader
+    @get:Internal
+    abstract val artifactsLoader: Property<BuiltArtifactsLoader>
 
     // As this task has no outputs defined, it will always be executed, which is desirable as the
     // APK should be installed even if the APK itself hasn't changed. (It may have been removed from
@@ -52,7 +55,8 @@ open class AdbInstallTask @Inject constructor(@Internal val execOperations: Exec
     @TaskAction
     fun install() {
         val artifacts =
-            artifactLoader.load(apkLocation.get()) ?: throw GradleException("Cannot load APKs")
+            artifactsLoader.get().load(apkLocation.get())
+                ?: throw GradleException("Cannot load APKs")
         if (artifacts.elements.size != 1)
             throw GradleException("Expected only one APK!")
         val apkPath = File(artifacts.elements.single().outputFile).toPath()

--- a/WatchFaceFormat/validator-plugin/plugins/src/main/kotlin/AdbInstallTask.kt
+++ b/WatchFaceFormat/validator-plugin/plugins/src/main/kotlin/AdbInstallTask.kt
@@ -20,9 +20,12 @@ import org.gradle.api.GradleException
 import org.gradle.api.file.Directory
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.options.Option
+import org.gradle.process.ExecOperations
 import java.io.File
+import javax.inject.Inject
 
 const val SET_WATCH_FACE_CMD =
     "shell am broadcast -a com.google.android.wearable.app.DEBUG_SURFACE --es operation set-watchface --es watchFaceId %s"
@@ -30,7 +33,8 @@ const val SET_WATCH_FACE_CMD =
 /**
  * Installs and sets watch face on an attached device via ADB.
  */
-open class AdbInstallTask : DefaultTask() {
+open class AdbInstallTask @Inject constructor(@Internal val execOperations: ExecOperations) :
+    DefaultTask() {
     @set:Option(option = "device", description = "The ADB device to install on")
     @get:Input
     var device: String = ""
@@ -57,13 +61,13 @@ open class AdbInstallTask : DefaultTask() {
         val installWatchFaceCmd = deviceArg + "install $apkPath"
         val setWatchFaceCmd = deviceArg + SET_WATCH_FACE_CMD.format(artifacts.applicationId)
 
-        project.exec {
+        execOperations.exec {
             val argsList = installWatchFaceCmd.split(" ").toList()
             it.commandLine("adb")
             it.args(argsList)
         }
 
-        project.exec {
+        execOperations.exec {
             val argsList = setWatchFaceCmd.split(" ").toList()
             it.commandLine("adb")
             it.args(argsList)

--- a/WatchFaceFormat/validator-plugin/plugins/src/main/kotlin/MemoryFootprintTask.kt
+++ b/WatchFaceFormat/validator-plugin/plugins/src/main/kotlin/MemoryFootprintTask.kt
@@ -34,11 +34,15 @@ import javax.inject.Inject
 /**
  * Runs the Memory Footprint checker tool.
  */
-abstract class MemoryFootprintTask @Inject constructor(@Internal val execOperations: ExecOperations) :
-    DefaultTask() {
+abstract class MemoryFootprintTask() : DefaultTask() {
     init {
+        // Setting the outputs to always be up to date, meaning that this task will only run if the
+        // input changes (or if the last run was not successful).
         this.outputs.upToDateWhen { true }
     }
+
+    @get:Inject
+    abstract val execOperations: ExecOperations
 
     @get:InputDirectory
     abstract val apkLocation: DirectoryProperty

--- a/WatchFaceFormat/validator-plugin/plugins/src/main/kotlin/ValidateWffFilesTask.kt
+++ b/WatchFaceFormat/validator-plugin/plugins/src/main/kotlin/ValidateWffFilesTask.kt
@@ -22,7 +22,6 @@ import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
-import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
@@ -36,11 +35,15 @@ import javax.inject.Inject
  * Runs the validator against WFF XML files.
  */
 @CacheableTask
-abstract class ValidateWffFilesTask @Inject constructor(@Internal val execOperations: ExecOperations) :
-    DefaultTask() {
+abstract class ValidateWffFilesTask : DefaultTask() {
     init {
+        // Setting the outputs to always be up to date, meaning that this task will only run if the
+        // input changes (or if the last run was not successful).
         this.outputs.upToDateWhen { true }
     }
+
+    @get:Inject
+    abstract val execOperations: ExecOperations
 
     @get:InputFiles
     @get:Incremental

--- a/WatchFaceFormat/validator-plugin/plugins/src/main/kotlin/WffToolDownloadTask.kt
+++ b/WatchFaceFormat/validator-plugin/plugins/src/main/kotlin/WffToolDownloadTask.kt
@@ -30,27 +30,27 @@ import org.gradle.api.tasks.TaskAction
 import java.nio.file.Path
 
 /**
- * Downloads the WFF validator for use in the build process.
+ * Downloads a WFF-related tool for use in the build process.
  */
 @CacheableTask
-abstract class ValidatorDownloadTask : DefaultTask() {
+abstract class WffToolDownloadTask : DefaultTask() {
     @get:OutputFile
-    abstract val validatorJarPath: RegularFileProperty
+    abstract val toolJarPath: RegularFileProperty
 
     @get:Input
-    abstract val validatorUrl: Property<String>
+    abstract val toolUrl: Property<String>
 
     @TaskAction
     fun install() {
-        downloadFileToPath(validatorJarPath.get().asFile.toPath(), validatorUrl.get())
+        downloadFileToPath(toolJarPath.get().asFile.toPath(), toolUrl.get())
     }
 
     private fun downloadFileToPath(filePath: Path, url: String) {
         val client = HttpClient { expectSuccess = true }
         val file = filePath.toFile()
 
-        // The validator generally won't exist already -- but there is the potential for the input
-        // URL to change, in which case the existing validator should be removed.
+        // The tool generally won't exist already -- but there is the potential for the input URL to
+        // change, in which case the existing validator should be removed.
         if (file.exists()) {
             file.delete()
         }

--- a/WatchFaceFormat/validator-plugin/plugins/src/main/kotlin/WffValidatorPlugin.kt
+++ b/WatchFaceFormat/validator-plugin/plugins/src/main/kotlin/WffValidatorPlugin.kt
@@ -38,9 +38,12 @@ private const val DEFAULT_RELEASE_TAG = "release"
 private const val VALIDATOR_URL =
     "https://github.com/google/watchface/releases/download/%s/dwf-format-2-validator-1.0.jar"
 private const val VALIDATOR_PATH = "validator/validator-%s.jar"
+private const val VALIDATOR_OUTPUT_PATH = "validator/validator-%s.txt"
+
 private const val MEMORY_FOOTPRINT_URL =
     "https://github.com/google/watchface/releases/download/%s/memory-footprint.jar"
 private const val MEMORY_FOOTPRINT_PATH = "memory-footprint/memory-footprint-%s.jar"
+private const val MEMORY_FOOTPRINT_OUTPUT_PATH = "memory-footprint/memory-footprint-%s.txt"
 
 class WffValidatorPlugin : Plugin<Project> {
     private lateinit var manifestPath: String
@@ -52,9 +55,12 @@ class WffValidatorPlugin : Plugin<Project> {
         val toolReleaseTag = project.properties["release"] ?: DEFAULT_RELEASE_TAG
 
         val validatorUrl = VALIDATOR_URL.format(toolReleaseTag)
-        val memoryFootprintUrl = MEMORY_FOOTPRINT_URL.format(toolReleaseTag)
         val validatorJar = VALIDATOR_PATH.format(toolReleaseTag)
+        val validatorOutput = VALIDATOR_OUTPUT_PATH.format(toolReleaseTag)
+
+        val memoryFootprintUrl = MEMORY_FOOTPRINT_URL.format(toolReleaseTag)
         val memoryFootprintJar = MEMORY_FOOTPRINT_PATH.format(toolReleaseTag)
+        val memoryFootprintOutput = MEMORY_FOOTPRINT_OUTPUT_PATH.format(toolReleaseTag)
 
         val validatorDownloadTask =
             project.tasks.register<WffToolDownloadTask>(DOWNLOAD_VALIDATOR_TASK) {
@@ -75,7 +81,9 @@ class WffValidatorPlugin : Plugin<Project> {
             if (wffFileCollection.isEmpty) {
                 throw GradleException("No WFF XML files found in project!")
             }
+            val validatorOutputPath = project.layout.buildDirectory.file(validatorOutput)
             validatorJarPath.set(validatorDownloadTask.get().toolJarPath)
+            validatorOutputFile.set(validatorOutputPath)
             wffFiles.setFrom(wffFileCollection)
             wffVersion.set(getWffVersion(manifestPath))
         }
@@ -108,10 +116,12 @@ class WffValidatorPlugin : Plugin<Project> {
             }
 
             proj.tasks.register<MemoryFootprintTask>(MEMORY_FOOTPRINT_TASK) {
+                val memoryFootprintOutputPath = project.layout.buildDirectory.file(memoryFootprintOutput)
                 memoryFootprintJarPath.set(memoryFootprintDownloadTask.get().toolJarPath)
                 apkLocation.set(apkDirectoryProvider)
                 artifactsLoader.set(loader)
                 wffVersion.set(getWffVersion(manifestPath))
+                memoryFootprintOutputFile.set(memoryFootprintOutputPath)
                 dependsOn(ASSEMBLE_DEBUG_TASK)
             }
         }


### PR DESCRIPTION
Adds an additional gradle task, to enable running the [Memory footprint evaluator](https://github.com/google/watchface/tree/main/play-validations).

Not run by default on each build, unlike the WFF validator, invoked using `./gradlew memoryFootprint`.