### PR TITLE
Updates Kotlin for DataLayer sample

### DIFF
--- a/DataLayer/Application/build.gradle.kts
+++ b/DataLayer/Application/build.gradle.kts
@@ -17,6 +17,7 @@
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
+    alias(libs.plugins.compose.compiler)
 }
 
 android {

--- a/DataLayer/Wearable/build.gradle.kts
+++ b/DataLayer/Wearable/build.gradle.kts
@@ -18,6 +18,7 @@ plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
     alias(libs.plugins.roborazzi)
+    alias(libs.plugins.compose.compiler)
 }
 
 android {

--- a/DataLayer/build.gradle.kts
+++ b/DataLayer/build.gradle.kts
@@ -27,6 +27,7 @@ plugins {
   alias(libs.plugins.com.diffplug.spotless) apply(false)
   alias(libs.plugins.com.android.application) apply(false)
   alias(libs.plugins.roborazzi) apply false
+  alias(libs.plugins.compose.compiler) apply false
 }
 
 subprojects {

--- a/DataLayer/gradle/libs.versions.toml
+++ b/DataLayer/gradle/libs.versions.toml
@@ -6,8 +6,8 @@ androidx-lifecycle = "2.8.7"
 androidx-wear-compose = "1.4.0"
 compose-compiler = "1.5.15"
 ktlint = "0.50.0"
-org-jetbrains-kotlin = "1.9.25"
-org-jetbrains-kotlinx = "1.9.0"
+kotlin = "2.1.0"
+org-jetbrains-kotlinx = "1.10.1"
 compose-ui-tooling = "1.4.0"
 robolectric = "4.14.1"
 roborazzi = "1.39.0"
@@ -25,13 +25,12 @@ androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-
 androidx-lifecycle-viewmodel-ktx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "androidx-lifecycle" }
 androidx-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "ui-test-junit4" }
 androidx-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "ui-test-manifest" }
-compose-compiler = { module = "androidx.compose.compiler:compiler", version.ref = "compose-compiler" }
 compose-foundation = { module = "androidx.compose.foundation:foundation" }
 compose-material = { module = "androidx.compose.material:material" }
 compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
 compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4" }
 jacoco-ant = "org.jacoco:org.jacoco.ant:0.8.12"
-kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "org-jetbrains-kotlin" }
+kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "org-jetbrains-kotlinx" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "org-jetbrains-kotlinx" }
 kotlinx-coroutines-play-services = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-play-services", version.ref = "org-jetbrains-kotlinx" }
@@ -56,3 +55,4 @@ test-ext-junit = "androidx.test.ext:junit:1.2.1"
 com-android-application = { id = "com.android.application", version.ref = "android-gradle-plugin" }
 com-diffplug-spotless = "com.diffplug.spotless:7.0.1"
 roborazzi = { id = "io.github.takahirom.roborazzi", version.ref = "roborazzi" }
+compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }


### PR DESCRIPTION
Looking at fixing the failure in https://github.com/android/wear-os-samples/pull/1232.
We have a rule to in renovate.json which I can't remember anymore why it's there, the sample seems to be working well with newest Kotlin/kotlinx
```
{
      "matchPackagePatterns": [
        "org.jetbrains.kotlin.*"
      ],
      "groupName": "kotlin",
      "allowedVersions": "<2.0.0"
    },
   ```