### PR TITLE
Add build workflows for Wear OS modules

### DIFF
--- a/.github/workflows/build-compose-starter.yml
+++ b/.github/workflows/build-compose-starter.yml
@@ -1,0 +1,33 @@
+# Workflow name
+name: Build Wear OS Compose Starter
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set Up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+          cache: 'gradle'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+        working-directory: ./ComposeStarter
+
+      - name: Build ComposeStarter app
+        working-directory: ./ComposeStarter
+        run: ./gradlew app:assembleDebug

--- a/.github/workflows/build-data-layer-application.yml
+++ b/.github/workflows/build-data-layer-application.yml
@@ -1,0 +1,33 @@
+# Workflow name
+name: Build Wear OS DataLayer Application
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set Up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+          cache: 'gradle'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+        working-directory: ./DataLayer
+
+      - name: Build DataLayer Application app
+        working-directory: ./DataLayer
+        run: ./gradlew Application:assembleDebug

--- a/.github/workflows/build-data-layer-wearable.yml
+++ b/.github/workflows/build-data-layer-wearable.yml
@@ -1,0 +1,33 @@
+# Workflow name
+name: Build Wear OS DataLayer Wearable
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set Up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+          cache: 'gradle'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+        working-directory: ./DataLayer
+
+      - name: Build DataLayer Wearable app
+        working-directory: ./DataLayer
+        run: ./gradlew Wearable:assembleDebug


### PR DESCRIPTION
This commit adds new GitHub Actions workflows to build the Wear OS Compose Starter and DataLayer modules. These workflows automate the build process for the following:

- Compose Starter app
- DataLayer Application app
- DataLayer Wearable app

The workflows are triggered on push, pull request, and workflow_dispatch events on the main branch. They set up JDK 17, Gradle, make gradlew executable, and build the specified module.