### PR TITLE
Updates WFP validator

### DIFF
--- a/WatchFacePush/app/build.gradle.kts
+++ b/WatchFacePush/app/build.gradle.kts
@@ -70,6 +70,8 @@ android {
     }
 }
 
+
+val mainAppNamespace = Attribute.of("wfp.app.namespace", String::class.java)
 // Define configurations that allows this app to include the sample watch faces in their assets
 configurations {
     create("debugWatchfaceOutput") {
@@ -95,6 +97,9 @@ configurations {
     create("cliToolConfiguration") {
         isCanBeConsumed = false
         isCanBeResolved = true
+        attributes {
+            attribute(mainAppNamespace, android.namespace!!)
+        }
     }
 }
 

--- a/WatchFacePush/build.gradle.kts
+++ b/WatchFacePush/build.gradle.kts
@@ -26,6 +26,8 @@ plugins {
     alias(libs.plugins.compose.compiler) apply false
 }
 
+val mainAppNamespace = Attribute.of("wfp.app.namespace", String::class.java)
+
 subprojects {
     if (!path.startsWith(":samples:")) {
         return@subprojects
@@ -60,8 +62,10 @@ subprojects {
                 val tokenTask =
                     tasks.register<TokenGenerationTask_gradle.TokenGenerationTask>("assembleToken$variantName") {
                         dependsOn(assembleTask)
-                        packageName.set(variant.namespace)
-                        cliToolClasspath.set(rootProject.project("app").configurations.getByName("cliToolConfiguration"))
+                        val cliConfiguration = rootProject.project("app").configurations.getByName("cliToolConfiguration")
+                        val mainAppPackageName = cliConfiguration.attributes.getAttribute(mainAppNamespace)
+                        cliToolClasspath.set(cliConfiguration)
+                        packageName.set(mainAppPackageName)
                         artifactsLoader.set(variant.artifacts.getBuiltArtifactsLoader())
                         apkLocation.set(variant.artifacts.get(SingleArtifact.APK))
 

--- a/WatchFacePush/gradle/libs.versions.toml
+++ b/WatchFacePush/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 agp = "8.10.1"
-validatorPushCli = "1.0.0-alpha01"
+validatorPushCli = "1.0.0-alpha02"
 wear-compose-material3 = "1.0.0-alpha37"
 wear-compose = "1.5.0-beta02"
 compose-tooling = "1.4.1"


### PR DESCRIPTION
Updates the WFP validator from alpha01 to alpha02

Also:

- Provides more useful output on failure from the WFP validator
- Fixes a small bug where the package name supplied to the validator was not from the main app, but just taken as a substring from the watch face being validated