### PR TITLE
Move some deps to debugImplementation()

### DIFF
--- a/WearTilesKotlin/app/build.gradle.kts
+++ b/WearTilesKotlin/app/build.gradle.kts
@@ -75,9 +75,11 @@ dependencies {
     implementation(libs.androidx.wear.protolayout.material3)
 
     // Tooling dependencies for previewing tiles in Android Studio.
-    // Scoped as 'implementation' to allow previews in the 'main' source set.
-    implementation(libs.androidx.wear.tiles.renderer)
+    debugImplementation(libs.androidx.wear.tiles.renderer)
+    debugImplementation(libs.androidx.compose.ui.tooling)
+    debugImplementation(libs.androidx.wear.tooling.preview)
+    // The tile preview code is in the same file as the tiles themselves, so we need to make the
+    // androidx.wear.tiles:tiles-tooling-preview dependency available to release builds, not
+    // just debug builds.
     implementation(libs.androidx.wear.tiles.tooling.preview)
-    implementation(libs.androidx.compose.ui.tooling)
-    implementation(libs.androidx.wear.tooling.preview)
 }


### PR DESCRIPTION
`androidx.wear.tiles:tiles-tooling-preview` still needs to be included in release builds.