### PR TITLE
Add Wear Tiles tooling dependency

### DIFF
--- a/WearTilesKotlin/app/build.gradle.kts
+++ b/WearTilesKotlin/app/build.gradle.kts
@@ -78,6 +78,7 @@ dependencies {
     debugImplementation(libs.androidx.wear.tiles.renderer)
     debugImplementation(libs.androidx.compose.ui.tooling)
     debugImplementation(libs.androidx.wear.tooling.preview)
+    debugImplementation(libs.androidx.wear.tiles.tooling)
     // The tile preview code is in the same file as the tiles themselves, so we need to make the
     // androidx.wear.tiles:tiles-tooling-preview dependency available to release builds, not
     // just debug builds.

--- a/WearTilesKotlin/gradle/libs.versions.toml
+++ b/WearTilesKotlin/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ androidx-wear-protolayout-material = { module = "androidx.wear.protolayout:proto
 androidx-wear-protolayout-material3 = { module = "androidx.wear.protolayout:protolayout-material3", version.ref = "androidx-wear-protolayout" }
 androidx-wear-tiles = { module = "androidx.wear.tiles:tiles", version.ref = "androidx-wear-tiles" }
 androidx-wear-tiles-renderer = { module = "androidx.wear.tiles:tiles-renderer", version.ref = "androidx-wear-tiles" }
+androidx-wear-tiles-tooling = { module = "androidx.wear.tiles:tiles-tooling", version.ref = "androidx-wear-tiles" }
 androidx-wear-tiles-tooling-preview = { module = "androidx.wear.tiles:tiles-tooling-preview", version.ref = "androidx-wear-tiles" }
 androidx-wear-tooling-preview = { module = "androidx.wear:wear-tooling-preview", version.ref = "wear-tooling-preview" }
 


### PR DESCRIPTION
This commit introduces the `androidx.wear.tiles:tiles-tooling` dependency to provide better tooling support for Wear OS Tiles development.

The following changes were made:
- Added `androidx-wear-tiles-tooling` to the `libs.versions.toml` file.
- Included the `debugImplementation(libs.androidx.wear.tiles.tooling)` dependency in the `app/build.gradle.kts` file.