### PR TITLE
Bump compileSDK for Complication sample

### DIFF
--- a/Complications/Wearable/build.gradle
+++ b/Complications/Wearable/build.gradle
@@ -21,15 +21,15 @@ plugins {
 }
 
 android {
-    compileSdk 35
+    compileSdk = 36
 
     namespace "com.example.android.wearable.wear.complications"
 
     defaultConfig {
         versionCode 1
         versionName "1.0"
-        minSdk 26
-        targetSdk 34
+        minSdk = 26
+        targetSdk = 36
     }
 
     lintOptions {


### PR DESCRIPTION
Bumping compileSDK for Complication sample otherwise [updates to other libraries](https://github.com/android/wear-os-samples/actions/runs/17225717586/job/48869758166?pr=1319) were failing and we are now at the right time to bump also target SDK.
