### PR TITLE
build(sdk): bump targetSdk and compileSdk to 37

### DIFF
--- a/Complications/Wearable/build.gradle
+++ b/Complications/Wearable/build.gradle
@@ -21,7 +21,7 @@ plugins {
 }
 
 android {
-    compileSdk = 36
+    compileSdk = 37
 
     namespace "com.example.android.wearable.wear.complications"
 
@@ -29,7 +29,7 @@ android {
         versionCode 1
         versionName "1.0"
         minSdk = 26
-        targetSdk = 36
+        targetSdk = 37
     }
 
     lintOptions {

--- a/ComposeStarter/app/build.gradle.kts
+++ b/ComposeStarter/app/build.gradle.kts
@@ -23,14 +23,14 @@ plugins {
 }
 
 android {
-    compileSdk = 36
+    compileSdk = 37
 
     namespace = "com.example.android.wearable.composestarter"
 
     defaultConfig {
         applicationId = "com.example.android.wearable.composestarter"
         minSdk = 26
-        targetSdk = 36
+        targetSdk = 37
         versionCode = 1
         versionName = "1.0"
     }

--- a/DataLayer/Application/build.gradle.kts
+++ b/DataLayer/Application/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
 }
 
 android {
-    compileSdk = 36
+    compileSdk = 37
 
     namespace = "com.example.android.wearable.datalayer"
 
@@ -31,7 +31,7 @@ android {
         versionCode = 1
         versionName = "1.0"
         minSdk = 23
-        targetSdk = 34
+        targetSdk = 37
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/DataLayer/Wearable/build.gradle.kts
+++ b/DataLayer/Wearable/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
 }
 
 android {
-    compileSdk = 36
+    compileSdk = 37
 
     namespace = "com.example.android.wearable.datalayer"
 
@@ -32,7 +32,7 @@ android {
         versionCode = 1
         versionName = "1.0"
         minSdk = 26
-        targetSdk = 34
+        targetSdk = 37
     }
 
     buildTypes {

--- a/WatchFaceFormat/Complications/watchface/build.gradle.kts
+++ b/WatchFaceFormat/Complications/watchface/build.gradle.kts
@@ -20,12 +20,12 @@ plugins {
 android {
     enableKotlin = false
     namespace = "com.example.complications"
-    compileSdk = 34
+    compileSdk = 37
 
     defaultConfig {
         applicationId = "com.example.complications"
         minSdk = 34
-        targetSdk = 34
+        targetSdk = 37
         versionCode = 1
         versionName = "1.0.0"
     }

--- a/WatchFaceFormat/Flavors/watchface/build.gradle.kts
+++ b/WatchFaceFormat/Flavors/watchface/build.gradle.kts
@@ -20,14 +20,14 @@ plugins {
 android {
     enableKotlin = false
     namespace = "com.example.flavors"
-    compileSdk = 34
+    compileSdk = 37
 
     defaultConfig {
         applicationId = "com.example.flavors"
         // Flavors requires version 2 of the watch face format, which is
         // supported from Wear OS 5 onwards.
         minSdk = 34
-        targetSdk = 34
+        targetSdk = 37
         versionCode = 1
         versionName = "1.0.0"
     }

--- a/WatchFaceFormat/PhotosMask/watchface/build.gradle.kts
+++ b/WatchFaceFormat/PhotosMask/watchface/build.gradle.kts
@@ -20,12 +20,12 @@ plugins {
 android {
     enableKotlin = false
     namespace = "com.example.photosmask"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         applicationId = "com.example.photosmask"
         minSdk = 36
-        targetSdk = 36
+        targetSdk = 37
         versionCode = 1
         versionName = "1.0.0"
     }

--- a/WatchFaceFormat/PhotosMulti/watchface/build.gradle.kts
+++ b/WatchFaceFormat/PhotosMulti/watchface/build.gradle.kts
@@ -20,12 +20,12 @@ plugins {
 android {
     enableKotlin = false
     namespace = "com.example.photosmulti"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         applicationId = "com.example.photosmulti"
         minSdk = 36
-        targetSdk = 36
+        targetSdk = 37
         versionCode = 1
         versionName = "1.0.0"
     }

--- a/WatchFaceFormat/SimpleAnalog/watchface/build.gradle.kts
+++ b/WatchFaceFormat/SimpleAnalog/watchface/build.gradle.kts
@@ -20,12 +20,12 @@ plugins {
 android {
     enableKotlin = false
     namespace = "com.example.simpleanalog"
-    compileSdk = 33
+    compileSdk = 37
 
     defaultConfig {
         applicationId = "com.example.simpleanalog"
         minSdk = 33
-        targetSdk = 33
+        targetSdk = 37
         versionCode = 1
         versionName = "1.0.0"
     }

--- a/WatchFaceFormat/SimpleDigital/watchface/build.gradle.kts
+++ b/WatchFaceFormat/SimpleDigital/watchface/build.gradle.kts
@@ -20,12 +20,12 @@ plugins {
 android {
     enableKotlin = false
     namespace = "com.example.simpledigital"
-    compileSdk = 33
+    compileSdk = 37
 
     defaultConfig {
         applicationId = "com.example.simpledigital"
         minSdk = 33
-        targetSdk = 33
+        targetSdk = 37
         versionCode = 1
         versionName = "1.0.0"
     }

--- a/WatchFaceFormat/Weather/watchface/build.gradle.kts
+++ b/WatchFaceFormat/Weather/watchface/build.gradle.kts
@@ -20,14 +20,14 @@ plugins {
 android {
     enableKotlin = false
     namespace = "com.example.weather"
-    compileSdk = 34
+    compileSdk = 37
 
     defaultConfig {
         applicationId = "com.example.weather"
         // Weather requires version 2 of the watch face format, which is
         // supported from Wear OS 5 onwards.
         minSdk = 34
-        targetSdk = 34
+        targetSdk = 37
         versionCode = 1
         versionName = "1.0.0"
     }

--- a/WatchFacePush/app/build.gradle.kts
+++ b/WatchFacePush/app/build.gradle.kts
@@ -30,12 +30,12 @@ plugins {
 // Watch Face Push requires API level 36 and above.
 android {
     namespace = "com.google.samples.marketplace"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         applicationId = "com.google.samples.marketplace"
         minSdk = 36
-        targetSdk = 36
+        targetSdk = 37
         versionCode = 2
         versionName = "1.1"
     }

--- a/WatchFacePush/samples/defaultwf/build.gradle.kts
+++ b/WatchFacePush/samples/defaultwf/build.gradle.kts
@@ -22,12 +22,12 @@ plugins {
 
 android {
     namespace = "com.google.samples.marketplace.watchfacepush.defaultwf"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         applicationId = "com.google.samples.marketplace.watchfacepush.defaultwf"
         minSdk = 33
-        targetSdk = 33
+        targetSdk = 37
         versionCode = 1
         versionName = "1.0"
     }

--- a/WatchFacePush/samples/firefly/build.gradle.kts
+++ b/WatchFacePush/samples/firefly/build.gradle.kts
@@ -20,12 +20,12 @@ plugins {
 
 android {
     namespace = "com.google.samples.marketplace.watchfacepush.firefly"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         applicationId = "com.google.samples.marketplace.watchfacepush.firefly"
         minSdk = 33
-        targetSdk = 33
+        targetSdk = 37
         versionCode = 1
         versionName = "1.0"
     }

--- a/WatchFacePush/samples/river/build.gradle.kts
+++ b/WatchFacePush/samples/river/build.gradle.kts
@@ -20,12 +20,12 @@ plugins {
 
 android {
     namespace = "com.google.samples.marketplace.watchfacepush.river"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         applicationId = "com.google.samples.marketplace.watchfacepush.river"
         minSdk = 33
-        targetSdk = 33
+        targetSdk = 37
         versionCode = 1
         versionName = "1.0"
     }

--- a/WearOAuth/oauth-device-grant/build.gradle
+++ b/WearOAuth/oauth-device-grant/build.gradle
@@ -21,13 +21,13 @@ plugins {
 }
 
 android {
-  compileSdk 36
+  compileSdk 37
   namespace "com.example.android.wearable.oauth.devicegrant"
 
   defaultConfig {
     applicationId "com.example.android.wearable.oauth.devicegrant"
     minSdk 26
-    targetSdk 34
+    targetSdk 37
     versionCode 1
     versionName "1.0"
   }

--- a/WearOAuth/oauth-pkce/build.gradle
+++ b/WearOAuth/oauth-pkce/build.gradle
@@ -21,13 +21,13 @@ plugins {
 }
 
 android {
-  compileSdk 36
+  compileSdk 37
   namespace "com.example.android.wearable.oauth.pkce"
 
   defaultConfig {
     applicationId "com.example.android.wearable.oauth.pkce"
     minSdk 26
-    targetSdk 34
+    targetSdk 37
     versionCode 1
     versionName "1.0"
   }

--- a/WearOAuth/util/build.gradle
+++ b/WearOAuth/util/build.gradle
@@ -19,13 +19,13 @@ plugins {
 }
 
 android {
-    compileSdk 34
+    compileSdk 37
 
     namespace 'com.example.android.wearable.oauth.util'
 
     defaultConfig {
         minSdk 23
-        targetSdk 33
+        targetSdk 37
         versionCode 1
         versionName "1.0"
 

--- a/WearSpeakerSample/wear/build.gradle.kts
+++ b/WearSpeakerSample/wear/build.gradle.kts
@@ -22,7 +22,7 @@ plugins {
 }
 
 android {
-    compileSdk = 36
+    compileSdk = 37
 
     namespace = "com.example.android.wearable.speaker"
 
@@ -30,7 +30,7 @@ android {
         versionCode = 1
         versionName = "1.0"
         minSdk = 26
-        targetSdk = 34
+        targetSdk = 37
     }
 
     buildTypes {

--- a/WearTilesKotlin/app/build.gradle.kts
+++ b/WearTilesKotlin/app/build.gradle.kts
@@ -30,7 +30,7 @@ android {
     defaultConfig {
         applicationId = "com.example.wear.tiles"
         minSdk = 30
-        targetSdk = 35
+        targetSdk = 37
         versionCode = 1
         versionName = "1.0"
     }


### PR DESCRIPTION
Upgrade all modules in the repository to target and compile with SDK 37 (Android 17) to ensure compatibility and consistency.

This includes the initial upgrade of WearTilesKotlin and the subsequent bulk upgrade of all sibling apps (Complications, ComposeStarter, DataLayer, WatchFaceFormat, WatchFacePush, WearOAuth, and WearSpeakerSample) using an automated script.

Verified that the WearTilesKotlin app builds and its messaging tile renders correctly on a Pixel Watch 3 emulator running API 37.
