### PR TITLE
Add Round preview suite and 320 DPI density specifications to WearWidget

### DIFF
--- a/WearWidget/app/src/main/java/com/google/example/wear_widget/HelloWidget.kt
+++ b/WearWidget/app/src/main/java/com/google/example/wear_widget/HelloWidget.kt
@@ -96,7 +96,11 @@ fun HelloWidgetRoundPreview(
     @PreviewParameter(RoundAllWidgetPreviewParams::class) params: WearWidgetParams
 ) = WearWidgetPreview(HelloWidget(), params)
 
-@Preview(name = "Play Store Asset", device = "spec:width=1000dp,height=1000dp,dpi=320")
+// Generates the uncropped rectangular preview images referenced by
+// <container previewImage="@drawable/..." /> in res/xml/hello_widget_info.xml.
+// Providing a full rectangular asset allows the system widget picker on each
+// device (Pixel Watch, Galaxy Watch, etc.) to apply its own native shape mask.
+@Preview(name = "Widget Picker Preview", device = "spec:width=1000dp,height=1000dp,dpi=320")
 @Composable
 fun HelloWidgetRectangularPreview(
     @PreviewParameter(RectangularAllWidgetPreviewParams::class) params: WearWidgetParams

--- a/WearWidget/app/src/main/java/com/google/example/wear_widget/HelloWidget.kt
+++ b/WearWidget/app/src/main/java/com/google/example/wear_widget/HelloWidget.kt
@@ -41,6 +41,7 @@ import androidx.glance.wear.WearWidgetDocument
 import androidx.glance.wear.color
 import androidx.glance.wear.core.WearWidgetParams
 import androidx.glance.wear.tooling.preview.RectangularAllWidgetPreviewParams
+import androidx.glance.wear.tooling.preview.RoundAllWidgetPreviewParams
 import androidx.glance.wear.tooling.preview.SquircleAllWidgetPreviewParams
 import androidx.glance.wear.tooling.preview.WearWidgetPreview
 import androidx.wear.compose.remote.material3.RemoteColorScheme
@@ -83,13 +84,19 @@ fun HelloWidgetContent() {
     }
 }
 
-@Preview
+@Preview(name = "Squircle Suite (Pixel Watch)", device = "spec:width=1000dp,height=1000dp,dpi=320")
 @Composable
 fun HelloWidgetSquirclePreview(
     @PreviewParameter(SquircleAllWidgetPreviewParams::class) params: WearWidgetParams
 ) = WearWidgetPreview(HelloWidget(), params)
 
-@Preview
+@Preview(name = "Round Suite (Galaxy Watch)", device = "spec:width=1000dp,height=1000dp,dpi=320")
+@Composable
+fun HelloWidgetRoundPreview(
+    @PreviewParameter(RoundAllWidgetPreviewParams::class) params: WearWidgetParams
+) = WearWidgetPreview(HelloWidget(), params)
+
+@Preview(name = "Play Store Catalog Asset", device = "spec:width=1000dp,height=1000dp,dpi=320")
 @Composable
 fun HelloWidgetRectangularPreview(
     @PreviewParameter(RectangularAllWidgetPreviewParams::class) params: WearWidgetParams

--- a/WearWidget/app/src/main/java/com/google/example/wear_widget/HelloWidget.kt
+++ b/WearWidget/app/src/main/java/com/google/example/wear_widget/HelloWidget.kt
@@ -84,19 +84,19 @@ fun HelloWidgetContent() {
     }
 }
 
-@Preview(name = "Squircle Suite (Pixel Watch)", device = "spec:width=1000dp,height=1000dp,dpi=320")
+@Preview(name = "Squircle Preview", device = "spec:width=1000dp,height=1000dp,dpi=320")
 @Composable
 fun HelloWidgetSquirclePreview(
     @PreviewParameter(SquircleAllWidgetPreviewParams::class) params: WearWidgetParams
 ) = WearWidgetPreview(HelloWidget(), params)
 
-@Preview(name = "Round Suite (Galaxy Watch)", device = "spec:width=1000dp,height=1000dp,dpi=320")
+@Preview(name = "Round Preview", device = "spec:width=1000dp,height=1000dp,dpi=320")
 @Composable
 fun HelloWidgetRoundPreview(
     @PreviewParameter(RoundAllWidgetPreviewParams::class) params: WearWidgetParams
 ) = WearWidgetPreview(HelloWidget(), params)
 
-@Preview(name = "Play Store Catalog Asset", device = "spec:width=1000dp,height=1000dp,dpi=320")
+@Preview(name = "Play Store Asset", device = "spec:width=1000dp,height=1000dp,dpi=320")
 @Composable
 fun HelloWidgetRectangularPreview(
     @PreviewParameter(RectangularAllWidgetPreviewParams::class) params: WearWidgetParams

--- a/WearWidget/app/src/main/java/com/google/example/wear_widget/WeatherWidget.kt
+++ b/WearWidget/app/src/main/java/com/google/example/wear_widget/WeatherWidget.kt
@@ -142,7 +142,11 @@ fun WeatherWidgetRoundPreview(
     @PreviewParameter(RoundAllWidgetPreviewParams::class) params: WearWidgetParams
 ) = WearWidgetPreview(MockWeatherWidget(75, WeatherCondition.SUNNY), params)
 
-@Preview(name = "Play Store Asset", device = "spec:width=1000dp,height=1000dp,dpi=320")
+// Generates the uncropped rectangular preview images referenced by
+// <container previewImage="@drawable/..." /> in res/xml/weather_widget_info.xml.
+// Providing a full rectangular asset allows the system widget picker on each
+// device (Pixel Watch, Galaxy Watch, etc.) to apply its own native shape mask.
+@Preview(name = "Widget Picker Preview", device = "spec:width=1000dp,height=1000dp,dpi=320")
 @Composable
 fun WeatherWidgetRectangularPreview(
     @PreviewParameter(RectangularAllWidgetPreviewParams::class) params: WearWidgetParams

--- a/WearWidget/app/src/main/java/com/google/example/wear_widget/WeatherWidget.kt
+++ b/WearWidget/app/src/main/java/com/google/example/wear_widget/WeatherWidget.kt
@@ -130,19 +130,19 @@ class MockWeatherWidget(private val temp: Int, private val condition: WeatherCon
     }
 }
 
-@Preview(name = "Squircle Suite (Pixel Watch)", device = "spec:width=1000dp,height=1000dp,dpi=320")
+@Preview(name = "Squircle Preview", device = "spec:width=1000dp,height=1000dp,dpi=320")
 @Composable
 fun WeatherWidgetSquirclePreview(
     @PreviewParameter(SquircleAllWidgetPreviewParams::class) params: WearWidgetParams
 ) = WearWidgetPreview(MockWeatherWidget(75, WeatherCondition.SUNNY), params)
 
-@Preview(name = "Round Suite (Galaxy Watch)", device = "spec:width=1000dp,height=1000dp,dpi=320")
+@Preview(name = "Round Preview", device = "spec:width=1000dp,height=1000dp,dpi=320")
 @Composable
 fun WeatherWidgetRoundPreview(
     @PreviewParameter(RoundAllWidgetPreviewParams::class) params: WearWidgetParams
 ) = WearWidgetPreview(MockWeatherWidget(75, WeatherCondition.SUNNY), params)
 
-@Preview(name = "Play Store Catalog Asset", device = "spec:width=1000dp,height=1000dp,dpi=320")
+@Preview(name = "Play Store Asset", device = "spec:width=1000dp,height=1000dp,dpi=320")
 @Composable
 fun WeatherWidgetRectangularPreview(
     @PreviewParameter(RectangularAllWidgetPreviewParams::class) params: WearWidgetParams

--- a/WearWidget/app/src/main/java/com/google/example/wear_widget/WeatherWidget.kt
+++ b/WearWidget/app/src/main/java/com/google/example/wear_widget/WeatherWidget.kt
@@ -46,6 +46,7 @@ import androidx.glance.wear.WearWidgetDocument
 import androidx.glance.wear.color
 import androidx.glance.wear.core.WearWidgetParams
 import androidx.glance.wear.tooling.preview.RectangularAllWidgetPreviewParams
+import androidx.glance.wear.tooling.preview.RoundAllWidgetPreviewParams
 import androidx.glance.wear.tooling.preview.SquircleAllWidgetPreviewParams
 import androidx.glance.wear.tooling.preview.WearWidgetPreview
 
@@ -129,13 +130,19 @@ class MockWeatherWidget(private val temp: Int, private val condition: WeatherCon
     }
 }
 
-@Preview
+@Preview(name = "Squircle Suite (Pixel Watch)", device = "spec:width=1000dp,height=1000dp,dpi=320")
 @Composable
 fun WeatherWidgetSquirclePreview(
     @PreviewParameter(SquircleAllWidgetPreviewParams::class) params: WearWidgetParams
 ) = WearWidgetPreview(MockWeatherWidget(75, WeatherCondition.SUNNY), params)
 
-@Preview
+@Preview(name = "Round Suite (Galaxy Watch)", device = "spec:width=1000dp,height=1000dp,dpi=320")
+@Composable
+fun WeatherWidgetRoundPreview(
+    @PreviewParameter(RoundAllWidgetPreviewParams::class) params: WearWidgetParams
+) = WearWidgetPreview(MockWeatherWidget(75, WeatherCondition.SUNNY), params)
+
+@Preview(name = "Play Store Catalog Asset", device = "spec:width=1000dp,height=1000dp,dpi=320")
 @Composable
 fun WeatherWidgetRectangularPreview(
     @PreviewParameter(RectangularAllWidgetPreviewParams::class) params: WearWidgetParams


### PR DESCRIPTION
### Summary & Goal

Updates the `WearWidget` reference sample to follow recommended preview configuration practices for Wear OS widgets:

1. **Multi-OEM Preview Coverage:** Adds `@Preview` configurations utilizing `RoundAllWidgetPreviewParams` alongside `SquircleAllWidgetPreviewParams` and `RectangularAllWidgetPreviewParams` to ensure developers can verify layouts for both major Wear OS container shapes (Squircle on Pixel Watch vs. Round/Pill on Galaxy Watch) as well as uncropped widget picker assets.
2. **Standard Watch Density (320 DPI):** Specifies explicit device density (`device = "spec:width=1000dp,height=1000dp,dpi=320"`) on all preview annotations. Without an explicit density, Android Studio defaults to phone density (420 DPI), causing Glance widget previews to render shrunken with scaling artifacts.
